### PR TITLE
Add new Fluentd -> S3 doc #227

### DIFF
--- a/enterprise/v0.16/07_monitor/04_logs-to-s3.md
+++ b/enterprise/v0.16/07_monitor/04_logs-to-s3.md
@@ -1,0 +1,138 @@
+---
+title: "Forward Astronomer Logs to Amazon S3"
+navTitle: "Forward Logs to S3"
+description: "How to configure Astronomer Enterprise to forward logs to Amazon S3."
+---
+
+## Overview
+
+If you're running Astronomer Enterprise and are interested in making Airflow task logs available in an Amazon S3 bucket, you're more than free to do so on the platform.
+
+For context, Astronomer Enterprise leverages [Fluentd](https://www.fluentd.org/) as a data collector that is responsible for scraping and cleaning Airflow task logs to then send to [Elasticsearch](https://www.elastic.co/elasticsearch/), a search engine used to centralize and index logs from Airflow. The Airflow Webserver pulls from Elasticsearch to render those logs directly to the user in the Airflow UI.
+
+The guidelines below will outline how to forward Airflow logs from Fluentd via an existing Fluentd to S3 plugin. For more information on the plugin itself, reference the following:
+
+- [Fluentd docs on the `out_s3` Output Plugin](https://docs.fluentd.org/output/s3)
+- [Fluentd GitHub repo for the Amazon S3 Plugin](https://github.com/fluent/fluent-plugin-s3)
+
+### Prerequisites
+
+To configure log forwarding from Fluentd to Amazon S3, you'll need:
+
+- An existing S3 Bucket
+- An EKS worker node autoscaling policy
+
+Follow the guidelines below for step-by-step instructions.
+
+### Configure IAM Policy and Role
+
+**1. Create an AWS IAM Policy with the following permissions**
+
+The first step in configuring Airflow task logs to be forwarded to Amazon S3 is to create an IAM Policy on AWS and grant it the following 3 roles:
+
+- `s3:ListBucket`
+- `s3:PutObject`
+- `s3:GetObject`
+
+The IAM Policy should look like the following:
+
+```
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:ListBucket"
+      ],
+      "Resource": "arn:aws:s3:::my-s3-bucket"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:PutObject",
+        "s3:GetObject"
+      ],
+      "Resource": "arn:aws:s3:::my-s3-bucket/*"
+    }
+  ]
+}
+```
+
+For more information on S3 permissions, read the ["Amazon S3 Actions" doc from AWS](https://docs.aws.amazon.com/AmazonS3/latest/dev/using-with-s3-actions.html).
+
+**2. Create an AWS IAM Role and attach the Policy created in Step 1**
+
+Now, create an IAM Role and attach the Policy created above. You can do so via the AWS Management Console or the AWS CLI, among other tools.
+
+For more information, refer to the ["Creating IAM Roles" doc from AWS](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create.html).
+
+### Configure EKS Worker Node Policy
+
+**1. Allow your EKS nodes to assume your new IAM Role**
+
+Find your EKS worker node autoscaling policy for your EKS cluster. The policy `arn` should look like: `arn:aws:iam::123456789:policy/eks-worker-autoscaling-astronomer-5dyw2O4d20200730104135818400000008`.
+
+Add the following section to the policy:
+
+```
+{
+    "Effect": "Allow",
+    "Action": "sts:AssumeRole",
+    "Resource": "arn:aws:iam::123456789:role/my-role"
+}
+```
+
+**2. Add a Trust Relationship between your EKS nodes and your new IAM Role**
+
+Add the following section to the role created in the section above:
+
+```
+{
+    "Effect": "Allow",
+    "Principal": {
+    "AWS": "arn:aws:iam::123456789:role/astronomer-5dyw2O4d20200730104135764200000006"
+    },
+    "Action": "sts:AssumeRole"
+}
+```
+
+This will allow your EKS nodes to assume the role created above, giving them the necessary permissions to write to S3.
+
+### Enable Fluentd to S3 in your `config.yaml`
+
+In the `config.yaml` file of Astronomer Enterprise, add the following:
+
+```
+fluentd:
+  s3:
+    enabled: true
+    role_arn: arn:aws:iam::123456789:role/my-role
+    role_session_name: my-session-name
+    s3_bucket: my-s3-bucket
+    s3_region: us-east-1
+```
+
+Make sure to replace all values above with your own.
+
+### Apply your Changes
+
+Once you save your changes to your `config.yaml` file, you'll need to upgrade the platform to apply them.
+
+First, identify your platform release name:
+
+```
+$ helm ls
+```
+
+Now, run the upgrade command:
+
+```
+$ helm upgrade <platform-release-name> -f config.yaml --version=<platform-version> astronomer/astronomer -n <your-namespace>
+```
+
+Make sure to substitute the values above with your own. For example, if you're running Astronomer v0.16.0 and your platform release name is `astronomer`, you might run:
+
+```
+$ helm upgrade astronomer -f config.yaml --version=0.17.0 astronomer/astronomer -n astronomer
+```


### PR DESCRIPTION
Porting over @ianstanton's [PR in /astronomer/docs ](https://github.com/astronomer/docs/pull/227) to this repo since we're planning on shipping these docs soon. Addresses astronomer/issues#1593

Notes:

- I changed the title to "Forward Astronomer Logs to Amazon S3"
- Menu = "Monitoring" (4th and last item) for _Enterprise Only_
- I cleaned up the format a bit and added some links to AWS docs that I thought would be helpful

In terms of content, @vparekh94 already approved this but I have two outstanding questions I want to make sure we address before we close out this PR:

1. What logs exactly are forwarded by default if you follow the guidelines in this doc? Is it Airflow task logs for all Airflow Deployments on the cluster, is it deployment-level logs (Webserver, Scheduler, Worker), or is it platform logs (Houston, registry, etc.)

2. Will those logs be _routed_ to S3 and no longer appear in elasticsearch, or will they still be sent to elasticsearch and a copy is exported to S3?

3. Is this functionality work on versions of Astro earlier than 0.16? Right now I only have it in that folder, but I can copy to earlier versions if they'd work just as well.