### PR TITLE
Fix a bunch of broken links. Trim whitespace.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Astronomer Documentation
 
-This repository contains all public [Astronomer Documentation](https://astronoemr.io/docs) files. Docs are stored in product-specific directories and are versioned in a way that aligns with our internal dev streams.
+This repository contains all public [Astronomer Documentation](https://astronomer.io/docs) files. Docs are stored in product-specific directories and are versioned in a way that aligns with our internal dev streams.
 
 ## Overview
 - [Cloud](https://astronomer.io/docs/cloud/stable): The default when a user visits our documentation site, these docs are continuously delivered along with Cloud features.
 - [Enterprise](https://astronomer.io/docs/enterprise/stable): These docs are fully versioned to align with the way our Enterprise users engage with and upgrade our product.
-- [AC](https://astronoemr.io/docs/certified/stable): These docs are hidden from the top-level nav for now, but are available to be shared on a case-by-case basis.
+- [AC](https://astronomer.io/docs/certified/stable): These docs are hidden from the top-level nav for now, but are available to be shared on a case-by-case basis.
 
 ## Cloud Docs
 
@@ -25,7 +25,7 @@ New features will need to be documented as they are rolled out to Cloud users.
 
 #### Quick Fixes
 
-Quick fixes can generally be reviewed and merged much more quickly than feature docs. 
+Quick fixes can generally be reviewed and merged much more quickly than feature docs.
 
 1. To fix a bug, branch off of main with a `hotfix/your-hotfix-branch` naming schema.
 2. Add your desired fixes to the appropriate documents.

--- a/cloud/stable/01_get-started/01_quickstart.md
+++ b/cloud/stable/01_get-started/01_quickstart.md
@@ -36,7 +36,7 @@ If you're new to Astronomer but someone else on your team has an existing Worksp
 
 [Role-based Access Control (RBAC)](https://www.astronomer.io/docs/rbac/) is a recent addition to our platform and allows you to give your teammates varying levels of permissions.
 
-**Note**: If you have any trouble with your invitation or confirmation email, check your spam filter. If that doesn't do the trick, [reach out to us](https://www.support.astronomer.io).
+**Note**: If you have any trouble with your invitation or confirmation email, check your spam filter. If that doesn't do the trick, [reach out to us](https://support.astronomer.io).
 
 ## Start with the Astronomer CLI
 
@@ -142,12 +142,12 @@ Step 1/1 : FROM astronomerinc/ap-airflow:latest-onbuild
  ---> 5160cfd00623
 Successfully built 5160cfd00623
 Successfully tagged astro-trial_705330/airflow:latest
-INFO[0000] [0/3] [postgres]: Starting                   
-INFO[0002] [1/3] [postgres]: Started                    
-INFO[0002] [1/3] [scheduler]: Starting                  
-INFO[0003] [2/3] [scheduler]: Started                   
-INFO[0003] [2/3] [webserver]: Starting                  
-INFO[0004] [3/3] [webserver]: Started                   
+INFO[0000] [0/3] [postgres]: Starting
+INFO[0002] [1/3] [postgres]: Started
+INFO[0002] [1/3] [scheduler]: Starting
+INFO[0003] [2/3] [scheduler]: Started
+INFO[0003] [2/3] [webserver]: Starting
+INFO[0004] [3/3] [webserver]: Started
 Airflow Webserver: http://localhost:8080
 Postgres Database: localhost:5432/postgres
 The default credentials are admin:admin

--- a/cloud/stable/03_deploy/02_deploy-cli.md
+++ b/cloud/stable/03_deploy/02_deploy-cli.md
@@ -29,7 +29,7 @@ To finish creating your Deployment, you'll have to:
 - Pick an Airflow Executor (Celery or Local)
 - Set Initial Resources
 
-![New Deployment Config](https://assets2.astronomer.io/main/docs/deploying-code/v0.15-new_deployment-config.png)
+![New Deployment Config](https://assets2.astronomer.io/main/docs/deploying-code/V0.15-new_deployment-config.png)
 
 ### Deployment Dashboard
 
@@ -82,8 +82,8 @@ $ astro workspace switch [UUID]
 
 ```
 $ astro deployment list
- NAME             RELEASE NAME             ASTRO      DEPLOYMENT ID                            
- demo_cluster     infrared-photon-7780     v0.17.0     c2436025-d501-4944-9c29-19ca61e7f359  
+ NAME             RELEASE NAME             ASTRO      DEPLOYMENT ID
+ demo_cluster     infrared-photon-7780     v0.17.0     c2436025-d501-4944-9c29-19ca61e7f359
 ```
 
 ### Deploy
@@ -120,7 +120,7 @@ This is largely dependent on personal preference and your particular use case.
 
 ### Workspace Level
 
-At a Workspace level, we recommend having 1 Astronomer Workspace per team of Airflow users. That way, anyone on each team has access to the same set of deployments under that Workspace (RBAC will soon allow you to adjust that access at a deployment level if you'd like). 
+At a Workspace level, we recommend having 1 Astronomer Workspace per team of Airflow users. That way, anyone on each team has access to the same set of deployments under that Workspace (RBAC will soon allow you to adjust that access at a deployment level if you'd like).
 
 ### Deployment Level
 

--- a/cloud/stable/03_deploy/06_ci-cd.md
+++ b/cloud/stable/03_deploy/06_ci-cd.md
@@ -150,7 +150,7 @@ Example:
 docker build -t registry.${BASE_DOMAIN}/${RELEASE_NAME}/airflow:ci-${DRONE_BUILD_NUMBER} .
 ```
 
-If you would like to see a more complete working example please visit our [full example using Drone-CI](https://github.com/astronomer/airflow-example-dags/blob/master/.drone.yml).
+If you would like to see a more complete working example please visit our [full example using Drone-CI](https://github.com/astronomer/airflow-example-dags/blob/main/.drone.yml).
 
 ### Configure Your CI/CD Pipeline
 
@@ -331,7 +331,7 @@ on: [push]
 
 jobs:
   build:
-    runs-on: ubuntu-latest    
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
     - name: Publish to Astronomer.io

--- a/cloud/stable/04_customize-airflow/04_airflow-alerts.md
+++ b/cloud/stable/04_customize-airflow/04_airflow-alerts.md
@@ -27,9 +27,9 @@ You will need fill out some boilerplate survey information, but it's a quick set
 
 A new account will be given 40k emails for the first 30 days and then 100 emails/day for free. As long as your DAGs are working properly, this should be more than enough for most use cases.
 
-After you create your account, you'll reach a view like below. 
+After you create your account, you'll reach a view like below.
 
-#### 2. Click on "Integrate using our Web API or SMTP relay"   
+#### 2. Click on "Integrate using our Web API or SMTP relay"
 ![Sendgrid Getting Started](https://assets2.astronomer.io/main/docs/emails/sendgrid_getting_started.png)
 
 #### 3. Choose the "Web API (recommended)" method
@@ -114,7 +114,7 @@ AIRFLOW__SMTP__SMTP_MAIL_FROM={ENTER_FROM_EMAIL_HERE}
 
 Email alerting set up via `email_on_failure` is handled at the task level. If a handful of your tasks fail for related reasons, you'll receive an individual email for each of those failures.
 
-If you're interested in limiting failure alerts to the DAG run level, you can instead pass `on_failure_callback` ([source](https://github.com/apache/airflow/blob/v1-10-stable/airflow/models.py#L3311)) directly in your DAG file to define a Python function that sends you an email denoting failure.
+If you're interested in limiting failure alerts to the DAG run level, you can instead pass `on_failure_callback` ([source](https://github.com/apache/airflow/blob/v1-10-stable/airflow/models/dag.py#L167)) directly in your DAG file to define a Python function that sends you an email denoting failure.
 
 ```
  :param on_failure_callback: A function to be called when a DagRun of this dag fails.

--- a/cloud/stable/05_manage-astronomer/01_workspace-permissions.md
+++ b/cloud/stable/05_manage-astronomer/01_workspace-permissions.md
@@ -6,7 +6,7 @@ description: "Manage user roles and permissions within a single Astronomer Works
 
 Astronomer supports role based access control (RBAC), allowing you to configure varying levels of access across all Users within your Workspace.
 
-The Astronomer image comes bundled with an [astronomer-fab-security manager package](https://github.com/astronomer/astronomer-fab-securitymanager/blob/4950500a51755f5b3d1ca288089404bfbd5fba60/README.md_) that connects permissions between
+The Astronomer image comes bundled with an [astronomer-fab-security manager package](https://github.com/astronomer/astronomer-fab-securitymanager/blob/3067c0470dbb1a528d1e251fb45312d01989e6a4/README.md) that connects permissions between
 Houston (the Astronomer API) and Airflow's built-in RBAC.
 
 For details on how those levels of permission are defined and how to leverage them on both Astronomer and Airflow, read the guidelines below.

--- a/enterprise/next/01_get-started/01_quickstart.md
+++ b/enterprise/next/01_get-started/01_quickstart.md
@@ -153,12 +153,12 @@ Successfully tagged hello-astro_fc483c/airflow:latest
 Creating network "helloastrofc483c_airflow" with driver "bridge"
 Creating volume "helloastrofc483c_postgres_data" with driver "local"
 Creating volume "helloastrofc483c_airflow_logs" with driver "local"
-INFO[0015] [0/3] [postgres]: Starting                   
-INFO[0015] [1/3] [postgres]: Started                    
-INFO[0015] [1/3] [scheduler]: Starting                  
-INFO[0016] [2/3] [scheduler]: Started                   
-INFO[0016] [2/3] [webserver]: Starting                  
-INFO[0016] [3/3] [webserver]: Started                   
+INFO[0015] [0/3] [postgres]: Starting
+INFO[0015] [1/3] [postgres]: Started
+INFO[0015] [1/3] [scheduler]: Starting
+INFO[0016] [2/3] [scheduler]: Started
+INFO[0016] [2/3] [webserver]: Starting
+INFO[0016] [3/3] [webserver]: Started
 Airflow Webserver: http://localhost:8080
 Postgres Database: localhost:5432/postgres
 The default credentials are admin:admin
@@ -181,11 +181,11 @@ Once authenticated, run:
 
 ```
 /hello-astro$ astro deploy
-Authenticated to democluster.astronomer-trials.com 
+Authenticated to democluster.astronomer-trials.com
 
 Select which airflow deployment you want to deploy to:
- #     LABEL     DEPLOYMENT NAME          WORKSPACE     DEPLOYMENT ID                 
- 1     Dev       dynamical-flare-3582     ETLs          ck8g10xxc1zfq0966xlefcpxu     
+ #     LABEL     DEPLOYMENT NAME          WORKSPACE     DEPLOYMENT ID
+ 1     Dev       dynamical-flare-3582     ETLs          ck8g10xxc1zfq0966xlefcpxu
 
 > 1
 Deploying: dynamical-flare-3582
@@ -207,20 +207,20 @@ Successfully built d6e82b576ce5
 Successfully tagged dynamical-flare-3582/airflow:latest
 Pushing image to Astronomer registry
 The push refers to repository [registry.democluster.astronomer-trials.com/dynamical-flare-3582/airflow]
-e5b0f4e97557: Pushed 
-e4f165f2c539: Pushed 
-7ae85d63186e: Pushed 
-3d6737106ee1: Pushed 
-cc0e1283f9aa: Pushed 
-7e57912de03a: Mounted from elementary-rocket-7360/airflow 
-e1aaa247f09d: Mounted from elementary-rocket-7360/airflow 
-c33dcb91918f: Mounted from elementary-rocket-7360/airflow 
-1cb60be4a43a: Mounted from elementary-rocket-7360/airflow 
-3fc755cc03d0: Mounted from elementary-rocket-7360/airflow 
-e09740f41293: Mounted from elementary-rocket-7360/airflow 
-5c858070b896: Mounted from elementary-rocket-7360/airflow 
-95df7c26d7c5: Mounted from elementary-rocket-7360/airflow 
-77cae8ab23bf: Mounted from elementary-rocket-7360/airflow 
+e5b0f4e97557: Pushed
+e4f165f2c539: Pushed
+7ae85d63186e: Pushed
+3d6737106ee1: Pushed
+cc0e1283f9aa: Pushed
+7e57912de03a: Mounted from elementary-rocket-7360/airflow
+e1aaa247f09d: Mounted from elementary-rocket-7360/airflow
+c33dcb91918f: Mounted from elementary-rocket-7360/airflow
+1cb60be4a43a: Mounted from elementary-rocket-7360/airflow
+3fc755cc03d0: Mounted from elementary-rocket-7360/airflow
+e09740f41293: Mounted from elementary-rocket-7360/airflow
+5c858070b896: Mounted from elementary-rocket-7360/airflow
+95df7c26d7c5: Mounted from elementary-rocket-7360/airflow
+77cae8ab23bf: Mounted from elementary-rocket-7360/airflow
 deploy-1: digest: sha256:9e69b7b81efc95c3f024f7656646b523f5b611c1954d52be6dca203c888fc842 size: 3230
 Untagged: registry.democluster.astronomer-trials.com/dynamical-flare-3582/airflow:deploy-1
 Untagged: registry.democluster.astronomer-trials.com/dynamical-flare-3582/airflow@sha256:9e69b7b81efc95c3f024f7656646b523f5b611c1954d52be6dca203c888fc842
@@ -250,6 +250,6 @@ These views show logs and metrics (respectively) acosss all deployments running 
 
 ## 10. Start inviting Users
 
-Now that you've run through all of the functionality on Astronomer enterprise, you're ready to start inviting users! 
+Now that you've run through all of the functionality on Astronomer enterprise, you're ready to start inviting users!
 
-To change the authentication system, naviate to our [Auth Systems](https://www.astronomer.io/docs/ee-integrating-auth-systems/) doc.
+To change the authentication system, naviate to our [Auth Systems](https://www.astronomer.io/docs/enterprise/stable/manage-astronomer/integrate-auth-system/) doc.

--- a/enterprise/next/01_get-started/02_faq.md
+++ b/enterprise/next/01_get-started/02_faq.md
@@ -48,16 +48,16 @@ You can find a list of all components used by the platform in the [Astronomer Pl
 No. Astronomer makes use of Kubernetes cluster-level features (including K8s RBAC) by design. These features include creating / deleting namespaces, daemonsets, roles, cluster-roles, service-accounts, resource-quotas, limit-ranges, etc. Additionally, Astronomer dynamically creates new airflow instances in separate namespaces, which protects data engineer users from noisy neighbors.
 
 * Roles
-  * [Houston](https://github.com/astronomer/astronomer/blob/v0.10.3-fix.4/charts/astronomer/templates/houston/houston-bootstrap-role.yaml)
-  * [Prisma](https://github.com/astronomer/astronomer/blob/v0.10.3-fix.4/charts/astronomer/templates/prisma/prisma-bootstrap-role.yaml)
-  * [Kubed](https://github.com/astronomer/astronomer/blob/v0.10.3-fix.4/charts/kubed/templates/kubed-clusterrole.yaml)
-  * [NGINX](https://github.com/astronomer/astronomer/blob/v0.10.3-fix.4/charts/nginx/templates/nginx-role.yaml)
-  * [Commander](https://github.com/astronomer/astronomer/blob/v0.10.3-fix.4/charts/astronomer/templates/commander/commander-role.yaml)
-  * [Fluentd](https://github.com/astronomer/astronomer/blob/v0.10.3-fix.4/charts/fluentd/templates/fluentd-clusterrole.yaml)
-  * [Prometheus](https://github.com/astronomer/astronomer/blob/v0.10.3-fix.4/charts/prometheus/templates/prometheus-role.yaml)
-  * [Grafana](https://github.com/astronomer/astronomer/blob/v0.10.3-fix.4/charts/grafana/templates/grafana-bootstrap-role.yaml)
-  * [Kubestate](https://github.com/astronomer/astronomer/blob/v0.10.3-fix.4/charts/kube-state/templates/kube-state-role.yaml)
-  * [Tiller](https://github.com/astronomer/astronomer/blob/tiller-clusterrole/charts/astronomer/templates/commander/tiller-clusterrole.yaml)
+  * [Houston](https://github.com/astronomer/astronomer/blob/master/charts/astronomer/templates/houston/api/houston-bootstrap-role.yaml)
+  * [Prisma](https://github.com/astronomer/astronomer/blob/master/charts/astronomer/templates/prisma/prisma-bootstrap-role.yaml)
+  * [Kubed](https://github.com/astronomer/astronomer/blob/master/charts/kubed/templates/kubed-clusterrole.yaml)
+  * [NGINX](https://github.com/astronomer/astronomer/blob/master/charts/nginx/templates/nginx-role.yaml)
+  * [Commander](https://github.com/astronomer/astronomer/blob/master/charts/astronomer/templates/commander/commander-role.yaml)
+  * [Fluentd](https://github.com/astronomer/astronomer/blob/master/charts/fluentd/templates/fluentd-clusterrole.yaml)
+  * [Prometheus](https://github.com/astronomer/astronomer/blob/master/charts/prometheus/templates/prometheus-role.yaml)
+  * [Grafana](https://github.com/astronomer/astronomer/blob/master/charts/grafana/templates/grafana-bootstrap-role.yaml)
+  * [Kubestate](https://github.com/astronomer/astronomer/blob/master/charts/kube-state/templates/kube-state-role.yaml)
+  * [Tiller](https://github.com/astronomer/astronomer/blob/master/charts/astronomer/templates/commander/commander-role.yaml)
 
 ### How can we restrict the application from getting full access?
 
@@ -85,13 +85,13 @@ You may have special requirements of your infrastructure such that you want to s
 
 ### How can we integrate with LDAP?
 
-See https://www.astronomer.io/docs/ee-integrating-auth-systems/
+See https://www.astronomer.io/docs/enterprise/stable/manage-astronomer/integrate-auth-system/
 
 ### How can we get multi-factor auth?
 
-Astronomer has a flexible [auth front end](https://www.astronomer.io/docs/ee-integrating-auth-systems/), with pre-built integrations for Google Auth, Okta, Auth0, and others.
+Astronomer has a flexible [auth front end](https://www.astronomer.io/docs/enterprise/stable/manage-astronomer/integrate-auth-system/), with pre-built integrations for Google Auth, Okta, Auth0, and others.
 
-If you choose to use Google Auth, we have [documentation available](https://www.astronomer.io/docs/ee-installation-google-oauth/). 
+If you choose to use Google Auth, we have [documentation available](https://www.astronomer.io/docs/ee-installation-google-oauth/).
 
 ### How can implement RBAC with this solution?
 

--- a/enterprise/next/03_install/01_aws/01_install-aws-standard.md
+++ b/enterprise/next/03_install/01_aws/01_install-aws-standard.md
@@ -25,7 +25,7 @@ All Astronomer services will be tied to a base domain of your choice, under whic
 
 Once created, your Astronomer base domain will be linked to a variety of sub-services that your users will access via the internet to manage, monitor and run Airflow on the platform.
 
-For the base domain `astro.mydomain.com`, for example, here are some corresponding URLs that your users would be able to reach: 
+For the base domain `astro.mydomain.com`, for example, here are some corresponding URLs that your users would be able to reach:
 
 * Astronomer UI: `app.astro.mydomain.com`
 * Airflow Deployments: `deployments.astro.mydomain.com/uniquely-generated-airflow-name/airflow`
@@ -38,7 +38,7 @@ For the full list of subdomains you need a certificate for, read below.
 
 To proceed with the installation, you'll need to spin up an [EKS Control Plane](https://aws.amazon.com/eks/) as well as worker nodes in your Kubernetes cluster by following [this AWS guide](https://docs.aws.amazon.com/eks/latest/userguide/getting-started.html).
 
-EKS is built off of Amazon's pre-existing EC2 service, so you can manage your Kubernetes nodes the same way you would manage your EC2 nodes. 
+EKS is built off of Amazon's pre-existing EC2 service, so you can manage your Kubernetes nodes the same way you would manage your EC2 nodes.
 
 As you follow the guide linked above, keep in mind:
 * Astronomer supports Kubernetes versions 1.14 and 1.15 (support for 1.16 coming soon).
@@ -169,7 +169,7 @@ nginx:
 
 #################################
 ### SMTP configuration
-#################################  
+#################################
 
 astronomer:
   houston:
@@ -177,7 +177,7 @@ astronomer:
       email:
         enabled: true
         smtpUrl: YOUR_URI_HERE
-``` 
+```
 
 SMTP is required and will allow users to send and accept email invites to Astronomer. The SMTP URI will take the following form:
 
@@ -188,7 +188,7 @@ smtpUrl: smtps://USERNAME:PW@HOST/?pool=true
 > **Note:** If you are using Amazon SES, your URL will look like the following:
 `smtpUrl: smtp://USERNAME:PW@HOST/?requireTLS=true`. If there are `/` or other escape characters in your username or password, you may need to [URL encode](https://www.urlencoder.org/) those characters.
 
-For more insight into how you might be able to customize Astronomer for your team, refer to step 12 at the bottom of this guide. 
+For more insight into how you might be able to customize Astronomer for your team, refer to step 12 at the bottom of this guide.
 
 ## 7. Install Astronomer
 
@@ -203,7 +203,7 @@ $ helm repo add astronomer https://helm.astronomer.io/
 $ helm install astronomer -f config.yaml --version=0.15.0 astronomer/astronomer --namespace astronomer
 ```
 
-This will generate a set of Kubernetes pods that will power the individual services required to run our platform, including the Astronomer UI, our Houston API, etc. 
+This will generate a set of Kubernetes pods that will power the individual services required to run our platform, including the Astronomer UI, our Houston API, etc.
 
 
 ## 8. Verify Pods are Up
@@ -263,7 +263,7 @@ If you are seeing issues here, check out our [guide on debugging your installati
 
 ## 9. Configure DNS
 
-Now that you've successfully installed Astronomer, a new Elastic Load Balancer (ELB) will have spun up in your AWS account. This ELB routes incoming traffic to our NGINX ingress controller.  
+Now that you've successfully installed Astronomer, a new Elastic Load Balancer (ELB) will have spun up in your AWS account. This ELB routes incoming traffic to our NGINX ingress controller.
 
 Run `kubectl get svc -n astronomer` to view your ELB's CNAME, located under the `EXTERNAL-IP` column for the `astronomer-nginx` service.
 
@@ -341,7 +341,7 @@ docker login registry.BASEDOMAIN -u _ p <token>
 
 To help you make the most of Astronomer Enterprise, take note of the following resources:
 
-* [Integrating an Auth System](https://www.astronomer.io/docs/ee-integrating-auth-system/)
+* [Integrating an Auth System](https://www.astronomer.io/docs/enterprise/stable/manage-astronomer/integrate-auth-system/)
 * [Configuring Platform Resources](https://www.astronomer.io/docs/ee-configuring-resources/)
 * [Managing Users on Astronomer Enterprise](https://www.astronomer.io/docs/ee-managing-users/)
 

--- a/enterprise/next/03_install/02_gcp/01_install-gcp-standard.md
+++ b/enterprise/next/03_install/02_gcp/01_install-gcp-standard.md
@@ -186,7 +186,7 @@ install.BASEDOMAIN
 
 ```
 
-You can also use a wildcard cert for yourdomain (e.g. `*.astro.BASEDOMAIN.com`). 
+You can also use a wildcard cert for yourdomain (e.g. `*.astro.BASEDOMAIN.com`).
 **Note:** You cannot use a self-signed certificate.
 
 
@@ -292,7 +292,7 @@ nginx:
 
 #################################
 ### SMTP configuration
-#################################  
+#################################
 
 astronomer:
   houston:
@@ -308,7 +308,7 @@ Note - the SMTP URI will take the form:
 smtpUrl: smtps://USERNAME:PW@HOST/?pool=true
 ```
 
-Check out our `Customizing Your Install` section for guidance on setting an [auth system](https://www.astronomer.io/docs/ee-integrating-auth-system/) and [resource requests(https://www.astronomer.io/docs/ee-configuring-resources/) in this `config.yaml`.
+Check out our `Customizing Your Install` section for guidance on setting an [auth system](https://www.astronomer.io/docs/enterprise/stable/manage-astronomer/integrate-auth-system/) and [resource requests(https://www.astronomer.io/docs/ee-configuring-resources/) in this `config.yaml`.
 
 ## 8. Install Astronomer
 
@@ -365,7 +365,7 @@ If you are seeing issues here, check out our [guide on debugging your installati
 
 Go to app.BASEDOMAIN to see the Astronomer UI.
 
-## 11. Verify SSL  
+## 11. Verify SSL
 
 To make sure that the certs were accepted, log into the platform and head to `app.BASEDOMAIN/token` and run:
 

--- a/enterprise/next/03_install/03_azure/01_install-azure-standard.md
+++ b/enterprise/next/03_install/03_azure/01_install-azure-standard.md
@@ -256,7 +256,7 @@ nginx:
 
 #################################
 ## SMTP configuration
-#################################  
+#################################
 
 astronomer:
   houston:
@@ -277,7 +277,7 @@ smtpUrl: smtps://USERNAME:PW@HOST/?pool=true
 $ helm install -f config.yaml . --namespace <my-namespace>
 ```
 
-Check out our `Customizing Your Install` section for guidance on setting an [auth system](https://www.astronomer.io/docs/ee-integrating-auth-system/) and [resource requests(https://www.astronomer.io/docs/ee-configuring-resources/) in this `config.yaml`.
+Check out our `Customizing Your Install` section for guidance on setting an [auth system](https://www.astronomer.io/docs/enterprise/stable/manage-astronomer/integrate-auth-system/) and [resource requests(https://www.astronomer.io/docs/ee-configuring-resources/) in this `config.yaml`.
 
 ## 10. Verify all pods are up
 

--- a/enterprise/next/04_deploy/02_deploy-code.md
+++ b/enterprise/next/04_deploy/02_deploy-code.md
@@ -15,7 +15,7 @@ In order to push up code to a deployment on Astronomer, you must have:
 
 ### Create a Deployment
 
-To create a deployment on Astronomer, log into the Astronomer UI on either: 
+To create a deployment on Astronomer, log into the Astronomer UI on either:
 - Astronomer Cloud
 - Your own domain on Astronomer Enterprise (`app.BASEDOMAIN`)
 
@@ -31,7 +31,7 @@ To finish creating your Deployment, you'll have to:
 - Pick an Airflow Executor (Celery or Local)
 - Set Initial Resources
 
-![New Deployment Config](https://assets2.astronomer.io/main/docs/deploying-code/v0.15-new_deployment-config.png)
+![New Deployment Config](https://assets2.astronomer.io/main/docs/deploying-code/V0.15-new_deployment-config.png)
 
 ### Deployment Dashboard
 
@@ -98,8 +98,8 @@ astro workspace switch [UUID]
 
 ```
 astro deployment list
- NAME           RELEASE NAME                 ASTRO      DEPLOYMENT ID                            
- demo_cluster     infrared-photon-7780     v0.7.5     c2436025-d501-4944-9c29-19ca61e7f359  
+ NAME           RELEASE NAME                 ASTRO      DEPLOYMENT ID
+ demo_cluster     infrared-photon-7780     v0.7.5     c2436025-d501-4944-9c29-19ca61e7f359
 ```
 
 ### Deploy
@@ -138,7 +138,7 @@ This is largely dependent on personal preference and your particular use case.
 
 ### Workspace Level
 
-At a Workspace level, we recommend having 1 Astronomer Workspace per team of Airflow users. That way, anyone on each team has access to the same set of deployments under that Workspace (RBAC will soon allow you to adjust that access at a deployment level if you'd like). 
+At a Workspace level, we recommend having 1 Astronomer Workspace per team of Airflow users. That way, anyone on each team has access to the same set of deployments under that Workspace (RBAC will soon allow you to adjust that access at a deployment level if you'd like).
 
 ### Deployment Level
 

--- a/enterprise/next/04_deploy/06_ci-cd.md
+++ b/enterprise/next/04_deploy/06_ci-cd.md
@@ -147,7 +147,7 @@ Example:
 docker build -t registry.${BASE_DOMAIN}/${RELEASE_NAME}/airflow:ci-${DRONE_BUILD_NUMBER} .
 ```
 
-If you would like to see a more complete working example please visit our [full example using Drone-CI](https://github.com/astronomer/airflow-example-dags/blob/master/.drone.yml).
+If you would like to see a more complete working example please visit our [full example using Drone-CI](https://github.com/astronomer/airflow-example-dags/blob/main/.drone.yml).
 
 ### Configure Your CI/CD Pipeline
 
@@ -330,7 +330,7 @@ on: [push]
 
 jobs:
   build:
-    runs-on: ubuntu-latest    
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
     - name: Publish to Astronomer.io

--- a/enterprise/next/05_customize-airflow/04_airflow-alerts.md
+++ b/enterprise/next/05_customize-airflow/04_airflow-alerts.md
@@ -27,9 +27,9 @@ You will need fill out some boilerplate survey information, but it's a quick set
 
 A new account will be given 40k emails for the first 30 days and then 100 emails/day for free. As long as your DAGs are working properly, this should be more than enough for most use cases.
 
-After you create your account, you'll reach a view like below. 
+After you create your account, you'll reach a view like below.
 
-#### 2. Click on "Integrate using our Web API or SMTP relay"   
+#### 2. Click on "Integrate using our Web API or SMTP relay"
 ![Sendgrid Getting Started](https://assets2.astronomer.io/main/docs/emails/sendgrid_getting_started.png)
 
 #### 3. Choose the "Web API (recommended)" method
@@ -114,7 +114,7 @@ AIRFLOW__SMTP__SMTP_MAIL_FROM={ENTER_FROM_EMAIL_HERE}
 
 Email alerting set up via `email_on_failure` is handled at the task level. If a handful of your tasks fail for related reasons, you'll receive an individual email for each of those failures.
 
-If you're interested in limiting failure alerts to the DAG run level, you can instead pass `on_failure_callback` ([source](https://github.com/apache/airflow/blob/v1-10-stable/airflow/models.py#L3311)) directly in your DAG file to define a Python function that sends you an email denoting failure.
+If you're interested in limiting failure alerts to the DAG run level, you can instead pass `on_failure_callback` ([source](https://github.com/apache/airflow/blob/v1-10-stable/airflow/models/dag.py#L167)) directly in your DAG file to define a Python function that sends you an email denoting failure.
 
 ```
  :param on_failure_callback: A function to be called when a DagRun of this dag fails.

--- a/enterprise/next/06_manage-astronomer/01_integrate-auth-system.md
+++ b/enterprise/next/06_manage-astronomer/01_integrate-auth-system.md
@@ -4,7 +4,7 @@ navTitle: "Integrate an Auth System"
 description: "Plug your internal authentication server into your Astronomer platform instantiation."
 ---
 
-By default, the Astronomer platform allows you to authenticate using your Google or GitHub account. We provide the option to authenticate using any alternative providers that follow the [Open Id Connect protocol](https://openid.net/connect/) via [Implicit Flow](https://auth0.com/docs/flows/concepts/implicit),  including (but not limited to) [Auth0](https://auth0.com/), [Okta](https://okta.com), and [Microsoft Azure's Active Directory](https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-protocols-oidc). 
+By default, the Astronomer platform allows you to authenticate using your Google or GitHub account. We provide the option to authenticate using any alternative providers that follow the [Open Id Connect protocol](https://openid.net/connect/) via [Implicit Flow](https://auth0.com/docs/flows/concepts/implicit),  including (but not limited to) [Auth0](https://auth0.com/), [Okta](https://www.okta.com), and [Microsoft Azure's Active Directory](https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-protocols-oidc).
 
 ## Configuration
 

--- a/enterprise/next/06_manage-astronomer/03_workspace-permissions.md
+++ b/enterprise/next/06_manage-astronomer/03_workspace-permissions.md
@@ -6,7 +6,7 @@ description: "Manage user roles and permissions within a single Astronomer Works
 
 Astronomer v0.9 and beyond supports role based access control (RBAC), allowing you to configure varying levels of access across all Users within your Workspace.
 
-The Astronomer image comes bundled with an [astronomer-fab-security manager package](https://github.com/astronomer/astronomer-fab-securitymanager/blob/4950500a51755f5b3d1ca288089404bfbd5fba60/README.md_) that connects permissions between
+The Astronomer image comes bundled with an [astronomer-fab-security manager package](https://github.com/astronomer/astronomer-fab-securitymanager/blob/3067c0470dbb1a528d1e251fb45312d01989e6a4/README.md) that connects permissions between
 Houston (the Astronomer API) and Airflow's built-in RBAC.
 
 For details on how those levels of permission are defined and how to leverage them on both Astronomer and Airflow, read the guidelines below.

--- a/enterprise/next/09_resources/01_release-notes.md
+++ b/enterprise/next/09_resources/01_release-notes.md
@@ -32,7 +32,7 @@ For more details on this new feature, reference our ["Environment Variables" doc
 
 Astronomer v0.16 for Astronomer Enterprise users comes with support for Microsoft's [Active Directory Federation services (AD FS)](https://docs.microsoft.com/en-us/windows-server/identity/active-directory-federation-services), as an alternative authentication system.
 
-To learn more, reference ["Auth Systems on Astronomer"](https://www.astronomer.io/docs/ee-integrating-auth-systems/).
+To learn more, reference ["Auth Systems on Astronomer"](https://www.astronomer.io/docs/enterprise/stable/manage-astronomer/integrate-auth-system/).
 
 ### Bug Fixes and Improvements
 

--- a/enterprise/v0.12/01_get-started/01_quickstart.md
+++ b/enterprise/v0.12/01_get-started/01_quickstart.md
@@ -153,12 +153,12 @@ Successfully tagged hello-astro_fc483c/airflow:latest
 Creating network "helloastrofc483c_airflow" with driver "bridge"
 Creating volume "helloastrofc483c_postgres_data" with driver "local"
 Creating volume "helloastrofc483c_airflow_logs" with driver "local"
-INFO[0015] [0/3] [postgres]: Starting                   
-INFO[0015] [1/3] [postgres]: Started                    
-INFO[0015] [1/3] [scheduler]: Starting                  
-INFO[0016] [2/3] [scheduler]: Started                   
-INFO[0016] [2/3] [webserver]: Starting                  
-INFO[0016] [3/3] [webserver]: Started                   
+INFO[0015] [0/3] [postgres]: Starting
+INFO[0015] [1/3] [postgres]: Started
+INFO[0015] [1/3] [scheduler]: Starting
+INFO[0016] [2/3] [scheduler]: Started
+INFO[0016] [2/3] [webserver]: Starting
+INFO[0016] [3/3] [webserver]: Started
 Airflow Webserver: http://localhost:8080
 Postgres Database: localhost:5432/postgres
 The default credentials are admin:admin
@@ -181,11 +181,11 @@ Once authenticated, run:
 
 ```
 /hello-astro$ astro deploy
-Authenticated to democluster.astronomer-trials.com 
+Authenticated to democluster.astronomer-trials.com
 
 Select which airflow deployment you want to deploy to:
- #     LABEL     DEPLOYMENT NAME          WORKSPACE     DEPLOYMENT ID                 
- 1     Dev       dynamical-flare-3582     ETLs          ck8g10xxc1zfq0966xlefcpxu     
+ #     LABEL     DEPLOYMENT NAME          WORKSPACE     DEPLOYMENT ID
+ 1     Dev       dynamical-flare-3582     ETLs          ck8g10xxc1zfq0966xlefcpxu
 
 > 1
 Deploying: dynamical-flare-3582
@@ -207,20 +207,20 @@ Successfully built d6e82b576ce5
 Successfully tagged dynamical-flare-3582/airflow:latest
 Pushing image to Astronomer registry
 The push refers to repository [registry.democluster.astronomer-trials.com/dynamical-flare-3582/airflow]
-e5b0f4e97557: Pushed 
-e4f165f2c539: Pushed 
-7ae85d63186e: Pushed 
-3d6737106ee1: Pushed 
-cc0e1283f9aa: Pushed 
-7e57912de03a: Mounted from elementary-rocket-7360/airflow 
-e1aaa247f09d: Mounted from elementary-rocket-7360/airflow 
-c33dcb91918f: Mounted from elementary-rocket-7360/airflow 
-1cb60be4a43a: Mounted from elementary-rocket-7360/airflow 
-3fc755cc03d0: Mounted from elementary-rocket-7360/airflow 
-e09740f41293: Mounted from elementary-rocket-7360/airflow 
-5c858070b896: Mounted from elementary-rocket-7360/airflow 
-95df7c26d7c5: Mounted from elementary-rocket-7360/airflow 
-77cae8ab23bf: Mounted from elementary-rocket-7360/airflow 
+e5b0f4e97557: Pushed
+e4f165f2c539: Pushed
+7ae85d63186e: Pushed
+3d6737106ee1: Pushed
+cc0e1283f9aa: Pushed
+7e57912de03a: Mounted from elementary-rocket-7360/airflow
+e1aaa247f09d: Mounted from elementary-rocket-7360/airflow
+c33dcb91918f: Mounted from elementary-rocket-7360/airflow
+1cb60be4a43a: Mounted from elementary-rocket-7360/airflow
+3fc755cc03d0: Mounted from elementary-rocket-7360/airflow
+e09740f41293: Mounted from elementary-rocket-7360/airflow
+5c858070b896: Mounted from elementary-rocket-7360/airflow
+95df7c26d7c5: Mounted from elementary-rocket-7360/airflow
+77cae8ab23bf: Mounted from elementary-rocket-7360/airflow
 deploy-1: digest: sha256:9e69b7b81efc95c3f024f7656646b523f5b611c1954d52be6dca203c888fc842 size: 3230
 Untagged: registry.democluster.astronomer-trials.com/dynamical-flare-3582/airflow:deploy-1
 Untagged: registry.democluster.astronomer-trials.com/dynamical-flare-3582/airflow@sha256:9e69b7b81efc95c3f024f7656646b523f5b611c1954d52be6dca203c888fc842
@@ -250,6 +250,6 @@ These views show logs and metrics (respectively) acosss all deployments running 
 
 ## 10. Start inviting Users
 
-Now that you've run through all of the functionality on Astronomer enterprise, you're ready to start inviting users! 
+Now that you've run through all of the functionality on Astronomer enterprise, you're ready to start inviting users!
 
-To change the authentication system, naviate to our [Auth Systems](https://www.astronomer.io/docs/ee-integrating-auth-systems/) doc.
+To change the authentication system, naviate to our [Auth Systems](https://www.astronomer.io/docs/enterprise/v0.12/manage-astronomer/integrate-auth-system/) doc.

--- a/enterprise/v0.12/01_get-started/02_faq.md
+++ b/enterprise/v0.12/01_get-started/02_faq.md
@@ -48,16 +48,16 @@ You can find a list of all components used by the platform in the [Astronomer Pl
 No. Astronomer makes use of Kubernetes cluster-level features (including K8s RBAC) by design. These features include creating / deleting namespaces, daemonsets, roles, cluster-roles, service-accounts, resource-quotas, limit-ranges, etc. Additionally, Astronomer dynamically creates new airflow instances in separate namespaces, which protects data engineer users from noisy neighbors.
 
 * Roles
-  * [Houston](https://github.com/astronomer/astronomer/blob/v0.10.3-fix.4/charts/astronomer/templates/houston/houston-bootstrap-role.yaml)
-  * [Prisma](https://github.com/astronomer/astronomer/blob/v0.10.3-fix.4/charts/astronomer/templates/prisma/prisma-bootstrap-role.yaml)
-  * [Kubed](https://github.com/astronomer/astronomer/blob/v0.10.3-fix.4/charts/kubed/templates/kubed-clusterrole.yaml)
-  * [NGINX](https://github.com/astronomer/astronomer/blob/v0.10.3-fix.4/charts/nginx/templates/nginx-role.yaml)
-  * [Commander](https://github.com/astronomer/astronomer/blob/v0.10.3-fix.4/charts/astronomer/templates/commander/commander-role.yaml)
-  * [Fluentd](https://github.com/astronomer/astronomer/blob/v0.10.3-fix.4/charts/fluentd/templates/fluentd-clusterrole.yaml)
-  * [Prometheus](https://github.com/astronomer/astronomer/blob/v0.10.3-fix.4/charts/prometheus/templates/prometheus-role.yaml)
-  * [Grafana](https://github.com/astronomer/astronomer/blob/v0.10.3-fix.4/charts/grafana/templates/grafana-bootstrap-role.yaml)
-  * [Kubestate](https://github.com/astronomer/astronomer/blob/v0.10.3-fix.4/charts/kube-state/templates/kube-state-role.yaml)
-  * [Tiller](https://github.com/astronomer/astronomer/blob/tiller-clusterrole/charts/astronomer/templates/commander/tiller-clusterrole.yaml)
+  * [Houston](https://github.com/astronomer/astronomer/blob/release-0.12/charts/astronomer/templates/houston/houston-bootstrap-role.yaml)
+  * [Prisma](https://github.com/astronomer/astronomer/blob/release-0.12/charts/astronomer/templates/prisma/prisma-bootstrap-role.yaml)
+  * [Kubed](https://github.com/astronomer/astronomer/blob/release-0.12/charts/kubed/templates/kubed-clusterrole.yaml)
+  * [NGINX](https://github.com/astronomer/astronomer/blob/release-0.12/charts/nginx/templates/nginx-role.yaml)
+  * [Commander](https://github.com/astronomer/astronomer/blob/release-0.12/charts/astronomer/templates/commander/commander-role.yaml)
+  * [Fluentd](https://github.com/astronomer/astronomer/blob/release-0.12/charts/fluentd/templates/fluentd-clusterrole.yaml)
+  * [Prometheus](https://github.com/astronomer/astronomer/blob/release-0.12/charts/prometheus/templates/prometheus-role.yaml)
+  * [Grafana](https://github.com/astronomer/astronomer/blob/release-0.12/charts/grafana/templates/grafana-bootstrap-role.yaml)
+  * [Kubestate](https://github.com/astronomer/astronomer/blob/release-0.12/charts/kube-state/templates/kube-state-role.yaml)
+  * [Tiller](https://github.com/astronomer/astronomer/blob/release-0.12/charts/astronomer/templates/commander/commander-role.yaml)
 
 ### How can we restrict the application from getting full access?
 
@@ -85,13 +85,13 @@ You may have special requirements of your infrastructure such that you want to s
 
 ### How can we integrate with LDAP?
 
-See https://www.astronomer.io/docs/ee-integrating-auth-systems/
+See https://www.astronomer.io/docs/enterprise/v0.12/manage-astronomer/integrate-auth-system/
 
 ### How can we get multi-factor auth?
 
-Astronomer has a flexible [auth front end](https://www.astronomer.io/docs/ee-integrating-auth-systems/), with pre-built integrations for Google Auth, Okta, Auth0, and others.
+Astronomer has a flexible [auth front end](https://www.astronomer.io/docs/enterprise/v0.12/manage-astronomer/integrate-auth-system/), with pre-built integrations for Google Auth, Okta, Auth0, and others.
 
-If you choose to use Google Auth, we have [documentation available](https://www.astronomer.io/docs/ee-installation-google-oauth/). 
+If you choose to use Google Auth, we have [documentation available](https://www.astronomer.io/docs/ee-installation-google-oauth/).
 
 ### How can implement RBAC with this solution?
 

--- a/enterprise/v0.12/03_install/01_aws/01_install-aws-standard.md
+++ b/enterprise/v0.12/03_install/01_aws/01_install-aws-standard.md
@@ -25,7 +25,7 @@ All Astronomer services will be tied to a base domain of your choice, under whic
 
 Once created, your Astronomer base domain will be linked to a variety of sub-services that your users will access via the internet to manage, monitor and run Airflow on the platform.
 
-For the base domain `astro.mydomain.com`, for example, here are some corresponding URLs that your users would be able to reach: 
+For the base domain `astro.mydomain.com`, for example, here are some corresponding URLs that your users would be able to reach:
 
 * Astronomer UI: `app.astro.mydomain.com`
 * Airflow Deployments: `deployments.astro.mydomain.com/uniquely-generated-airflow-name/airflow`
@@ -38,7 +38,7 @@ For the full list of subdomains you need a certificate for, read below.
 
 To proceed with the installation, you'll need to spin up an [EKS Control Plane](https://aws.amazon.com/eks/) as well as worker nodes in your Kubernetes cluster by following [this AWS guide](https://docs.aws.amazon.com/eks/latest/userguide/getting-started.html).
 
-EKS is built off of Amazon's pre-existing EC2 service, so you can manage your Kubernetes nodes the same way you would manage your EC2 nodes. 
+EKS is built off of Amazon's pre-existing EC2 service, so you can manage your Kubernetes nodes the same way you would manage your EC2 nodes.
 
 As you follow the guide linked above, keep in mind:
 * Astronomer supports Kubernetes versions 1.14 and 1.15 (support for 1.16 coming soon).
@@ -169,7 +169,7 @@ nginx:
 
 #################################
 ### SMTP configuration
-#################################  
+#################################
 
 astronomer:
   houston:
@@ -177,7 +177,7 @@ astronomer:
       email:
         enabled: true
         smtpUrl: YOUR_URI_HERE
-``` 
+```
 
 SMTP is required and will allow users to send and accept email invites to Astronomer. The SMTP URI will take the following form:
 
@@ -188,7 +188,7 @@ smtpUrl: smtps://USERNAME:PW@HOST/?pool=true
 > **Note:** If you are using Amazon SES, your URL will look like the following:
 `smtpUrl: smtp://USERNAME:PW@HOST/?requireTLS=true`. If there are `/` or other escape characters in your username or password, you may need to [URL encode](https://www.urlencoder.org/) those characters.
 
-For more insight into how you might be able to customize Astronomer for your team, refer to step 12 at the bottom of this guide. 
+For more insight into how you might be able to customize Astronomer for your team, refer to step 12 at the bottom of this guide.
 
 ## 7. Install Astronomer
 
@@ -203,7 +203,7 @@ $ helm repo add astronomer https://helm.astronomer.io/
 $ helm install astronomer -f config.yaml --version=0.15.0 astronomer/astronomer --namespace astronomer
 ```
 
-This will generate a set of Kubernetes pods that will power the individual services required to run our platform, including the Astronomer UI, our Houston API, etc. 
+This will generate a set of Kubernetes pods that will power the individual services required to run our platform, including the Astronomer UI, our Houston API, etc.
 
 
 ## 8. Verify Pods are Up
@@ -263,7 +263,7 @@ If you are seeing issues here, check out our [guide on debugging your installati
 
 ## 9. Configure DNS
 
-Now that you've successfully installed Astronomer, a new Elastic Load Balancer (ELB) will have spun up in your AWS account. This ELB routes incoming traffic to our NGINX ingress controller.  
+Now that you've successfully installed Astronomer, a new Elastic Load Balancer (ELB) will have spun up in your AWS account. This ELB routes incoming traffic to our NGINX ingress controller.
 
 Run `kubectl get svc -n astronomer` to view your ELB's CNAME, located under the `EXTERNAL-IP` column for the `astronomer-nginx` service.
 
@@ -341,7 +341,7 @@ docker login registry.BASEDOMAIN -u _ p <token>
 
 To help you make the most of Astronomer Enterprise, take note of the following resources:
 
-* [Integrating an Auth System](https://www.astronomer.io/docs/ee-integrating-auth-system/)
+* [Integrating an Auth System](https://www.astronomer.io/docs/enterprise/v0.12/manage-astronomer/integrate-auth-system/)
 * [Configuring Platform Resources](https://www.astronomer.io/docs/ee-configuring-resources/)
 * [Managing Users on Astronomer Enterprise](https://www.astronomer.io/docs/ee-managing-users/)
 

--- a/enterprise/v0.12/03_install/02_gcp/01_install-gcp-standard.md
+++ b/enterprise/v0.12/03_install/02_gcp/01_install-gcp-standard.md
@@ -186,7 +186,7 @@ install.BASEDOMAIN
 
 ```
 
-You can also use a wildcard cert for yourdomain (e.g. `*.astro.BASEDOMAIN.com`). 
+You can also use a wildcard cert for yourdomain (e.g. `*.astro.BASEDOMAIN.com`).
 **Note:** You cannot use a self-signed certificate.
 
 
@@ -292,7 +292,7 @@ nginx:
 
 #################################
 ### SMTP configuration
-#################################  
+#################################
 
 astronomer:
   houston:
@@ -308,7 +308,7 @@ Note - the SMTP URI will take the form:
 smtpUrl: smtps://USERNAME:PW@HOST/?pool=true
 ```
 
-Check out our `Customizing Your Install` section for guidance on setting an [auth system](https://www.astronomer.io/docs/ee-integrating-auth-system/) and [resource requests(https://www.astronomer.io/docs/ee-configuring-resources/) in this `config.yaml`.
+Check out our `Customizing Your Install` section for guidance on setting an [auth system](https://www.astronomer.io/docs/enterprise/v0.12/manage-astronomer/integrate-auth-system/) and [resource requests(https://www.astronomer.io/docs/ee-configuring-resources/) in this `config.yaml`.
 
 ## 8. Install Astronomer
 
@@ -365,7 +365,7 @@ If you are seeing issues here, check out our [guide on debugging your installati
 
 Go to app.BASEDOMAIN to see the Astronomer UI.
 
-## 11. Verify SSL  
+## 11. Verify SSL
 
 To make sure that the certs were accepted, log into the platform and head to `app.BASEDOMAIN/token` and run:
 

--- a/enterprise/v0.12/03_install/03_azure/01_install-azure-standard.md
+++ b/enterprise/v0.12/03_install/03_azure/01_install-azure-standard.md
@@ -256,7 +256,7 @@ nginx:
 
 #################################
 ## SMTP configuration
-#################################  
+#################################
 
 astronomer:
   houston:
@@ -277,7 +277,7 @@ smtpUrl: smtps://USERNAME:PW@HOST/?pool=true
 $ helm install -f config.yaml . --namespace <my-namespace>
 ```
 
-Check out our `Customizing Your Install` section for guidance on setting an [auth system](https://www.astronomer.io/docs/ee-integrating-auth-system/) and [resource requests(https://www.astronomer.io/docs/ee-configuring-resources/) in this `config.yaml`.
+Check out our `Customizing Your Install` section for guidance on setting an [auth system](https://www.astronomer.io/docs/enterprise/v0.12/manage-astronomer/integrate-auth-system/) and [resource requests(https://www.astronomer.io/docs/ee-configuring-resources/) in this `config.yaml`.
 
 ## 10. Verify all pods are up
 

--- a/enterprise/v0.12/04_deploy/02_deploy-code.md
+++ b/enterprise/v0.12/04_deploy/02_deploy-code.md
@@ -15,7 +15,7 @@ In order to push up code to a deployment on Astronomer, you must have:
 
 ### Create a Deployment
 
-To create a deployment on Astronomer, log into the Astronomer UI on either: 
+To create a deployment on Astronomer, log into the Astronomer UI on either:
 - Astronomer Cloud
 - Your own domain on Astronomer Enterprise (`app.BASEDOMAIN`)
 
@@ -31,7 +31,7 @@ To finish creating your Deployment, you'll have to:
 - Pick an Airflow Executor (Celery or Local)
 - Set Initial Resources
 
-![New Deployment Config](https://assets2.astronomer.io/main/docs/deploying-code/v0.15-new_deployment-config.png)
+![New Deployment Config](https://assets2.astronomer.io/main/docs/deploying-code/V0.15-new_deployment-config.png)
 
 ### Deployment Dashboard
 
@@ -98,8 +98,8 @@ astro workspace switch [UUID]
 
 ```
 astro deployment list
- NAME           RELEASE NAME                 ASTRO      DEPLOYMENT ID                            
- demo_cluster     infrared-photon-7780     v0.7.5     c2436025-d501-4944-9c29-19ca61e7f359  
+ NAME           RELEASE NAME                 ASTRO      DEPLOYMENT ID
+ demo_cluster     infrared-photon-7780     v0.7.5     c2436025-d501-4944-9c29-19ca61e7f359
 ```
 
 ### Deploy
@@ -138,7 +138,7 @@ This is largely dependent on personal preference and your particular use case.
 
 ### Workspace Level
 
-At a Workspace level, we recommend having 1 Astronomer Workspace per team of Airflow users. That way, anyone on each team has access to the same set of deployments under that Workspace (RBAC will soon allow you to adjust that access at a deployment level if you'd like). 
+At a Workspace level, we recommend having 1 Astronomer Workspace per team of Airflow users. That way, anyone on each team has access to the same set of deployments under that Workspace (RBAC will soon allow you to adjust that access at a deployment level if you'd like).
 
 ### Deployment Level
 

--- a/enterprise/v0.12/04_deploy/06_ci-cd.md
+++ b/enterprise/v0.12/04_deploy/06_ci-cd.md
@@ -147,7 +147,7 @@ Example:
 docker build -t registry.${BASE_DOMAIN}/${RELEASE_NAME}/airflow:ci-${DRONE_BUILD_NUMBER} .
 ```
 
-If you would like to see a more complete working example please visit our [full example using Drone-CI](https://github.com/astronomer/airflow-example-dags/blob/master/.drone.yml).
+If you would like to see a more complete working example please visit our [full example using Drone-CI](https://github.com/astronomer/airflow-example-dags/blob/main/.drone.yml).
 
 ### Configure Your CI/CD Pipeline
 
@@ -330,7 +330,7 @@ on: [push]
 
 jobs:
   build:
-    runs-on: ubuntu-latest    
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
     - name: Publish to Astronomer.io

--- a/enterprise/v0.12/05_customize-airflow/04_airflow-alerts.md
+++ b/enterprise/v0.12/05_customize-airflow/04_airflow-alerts.md
@@ -27,9 +27,9 @@ You will need fill out some boilerplate survey information, but it's a quick set
 
 A new account will be given 40k emails for the first 30 days and then 100 emails/day for free. As long as your DAGs are working properly, this should be more than enough for most use cases.
 
-After you create your account, you'll reach a view like below. 
+After you create your account, you'll reach a view like below.
 
-#### 2. Click on "Integrate using our Web API or SMTP relay"   
+#### 2. Click on "Integrate using our Web API or SMTP relay"
 ![Sendgrid Getting Started](https://assets2.astronomer.io/main/docs/emails/sendgrid_getting_started.png)
 
 #### 3. Choose the "Web API (recommended)" method
@@ -114,7 +114,7 @@ AIRFLOW__SMTP__SMTP_MAIL_FROM={ENTER_FROM_EMAIL_HERE}
 
 Email alerting set up via `email_on_failure` is handled at the task level. If a handful of your tasks fail for related reasons, you'll receive an individual email for each of those failures.
 
-If you're interested in limiting failure alerts to the DAG run level, you can instead pass `on_failure_callback` ([source](https://github.com/apache/airflow/blob/v1-10-stable/airflow/models.py#L3311)) directly in your DAG file to define a Python function that sends you an email denoting failure.
+If you're interested in limiting failure alerts to the DAG run level, you can instead pass `on_failure_callback` ([source](https://github.com/apache/airflow/blob/v1-10-stable/airflow/models/dag.py#L167)) directly in your DAG file to define a Python function that sends you an email denoting failure.
 
 ```
  :param on_failure_callback: A function to be called when a DagRun of this dag fails.

--- a/enterprise/v0.12/06_manage-astronomer/01_integrate-auth-system.md
+++ b/enterprise/v0.12/06_manage-astronomer/01_integrate-auth-system.md
@@ -4,7 +4,7 @@ navTitle: "Integrate an Auth System"
 description: "Plug your internal authentication server into your Astronomer platform instantiation."
 ---
 
-By default, the Astronomer platform allows you to authenticate using your Google or GitHub account. We provide the option to authenticate using any alternative providers that follow the [Open Id Connect protocol](https://openid.net/connect/) via [Implicit Flow](https://auth0.com/docs/flows/concepts/implicit),  including (but not limited to) [Auth0](https://auth0.com/), [Okta](https://okta.com), and [Microsoft Azure's Active Directory](https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-protocols-oidc). 
+By default, the Astronomer platform allows you to authenticate using your Google or GitHub account. We provide the option to authenticate using any alternative providers that follow the [Open Id Connect protocol](https://openid.net/connect/) via [Implicit Flow](https://auth0.com/docs/flows/concepts/implicit),  including (but not limited to) [Auth0](https://auth0.com/), [Okta](https://www.okta.com), and [Microsoft Azure's Active Directory](https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-protocols-oidc).
 
 ## Configuration
 

--- a/enterprise/v0.12/06_manage-astronomer/03_workspace-permissions.md
+++ b/enterprise/v0.12/06_manage-astronomer/03_workspace-permissions.md
@@ -6,7 +6,7 @@ description: "Manage user roles and permissions within a single Astronomer Works
 
 Astronomer v0.9 and beyond supports role based access control (RBAC), allowing you to configure varying levels of access across all Users within your Workspace.
 
-The Astronomer image comes bundled with an [astronomer-fab-security manager package](https://github.com/astronomer/astronomer-fab-securitymanager/blob/4950500a51755f5b3d1ca288089404bfbd5fba60/README.md_) that connects permissions between
+The Astronomer image comes bundled with an [astronomer-fab-security manager package](https://github.com/astronomer/astronomer-fab-securitymanager/blob/3067c0470dbb1a528d1e251fb45312d01989e6a4/README.md) that connects permissions between
 Houston (the Astronomer API) and Airflow's built-in RBAC.
 
 For details on how those levels of permission are defined and how to leverage them on both Astronomer and Airflow, read the guidelines below.

--- a/enterprise/v0.12/09_resources/01_release-notes.md
+++ b/enterprise/v0.12/09_resources/01_release-notes.md
@@ -32,7 +32,7 @@ For more details on this new feature, reference our ["Environment Variables" doc
 
 Astronomer v0.16 for Astronomer Enterprise users comes with support for Microsoft's [Active Directory Federation services (AD FS)](https://docs.microsoft.com/en-us/windows-server/identity/active-directory-federation-services), as an alternative authentication system.
 
-To learn more, reference ["Auth Systems on Astronomer"](https://www.astronomer.io/docs/ee-integrating-auth-systems/).
+To learn more, reference ["Auth Systems on Astronomer"](https://www.astronomer.io/docs/enterprise/v0.12/manage-astronomer/integrate-auth-system/).
 
 ### Bug Fixes and Improvements
 

--- a/enterprise/v0.13/01_get-started/01_quickstart.md
+++ b/enterprise/v0.13/01_get-started/01_quickstart.md
@@ -153,12 +153,12 @@ Successfully tagged hello-astro_fc483c/airflow:latest
 Creating network "helloastrofc483c_airflow" with driver "bridge"
 Creating volume "helloastrofc483c_postgres_data" with driver "local"
 Creating volume "helloastrofc483c_airflow_logs" with driver "local"
-INFO[0015] [0/3] [postgres]: Starting                   
-INFO[0015] [1/3] [postgres]: Started                    
-INFO[0015] [1/3] [scheduler]: Starting                  
-INFO[0016] [2/3] [scheduler]: Started                   
-INFO[0016] [2/3] [webserver]: Starting                  
-INFO[0016] [3/3] [webserver]: Started                   
+INFO[0015] [0/3] [postgres]: Starting
+INFO[0015] [1/3] [postgres]: Started
+INFO[0015] [1/3] [scheduler]: Starting
+INFO[0016] [2/3] [scheduler]: Started
+INFO[0016] [2/3] [webserver]: Starting
+INFO[0016] [3/3] [webserver]: Started
 Airflow Webserver: http://localhost:8080
 Postgres Database: localhost:5432/postgres
 The default credentials are admin:admin
@@ -181,11 +181,11 @@ Once authenticated, run:
 
 ```
 /hello-astro$ astro deploy
-Authenticated to democluster.astronomer-trials.com 
+Authenticated to democluster.astronomer-trials.com
 
 Select which airflow deployment you want to deploy to:
- #     LABEL     DEPLOYMENT NAME          WORKSPACE     DEPLOYMENT ID                 
- 1     Dev       dynamical-flare-3582     ETLs          ck8g10xxc1zfq0966xlefcpxu     
+ #     LABEL     DEPLOYMENT NAME          WORKSPACE     DEPLOYMENT ID
+ 1     Dev       dynamical-flare-3582     ETLs          ck8g10xxc1zfq0966xlefcpxu
 
 > 1
 Deploying: dynamical-flare-3582
@@ -207,20 +207,20 @@ Successfully built d6e82b576ce5
 Successfully tagged dynamical-flare-3582/airflow:latest
 Pushing image to Astronomer registry
 The push refers to repository [registry.democluster.astronomer-trials.com/dynamical-flare-3582/airflow]
-e5b0f4e97557: Pushed 
-e4f165f2c539: Pushed 
-7ae85d63186e: Pushed 
-3d6737106ee1: Pushed 
-cc0e1283f9aa: Pushed 
-7e57912de03a: Mounted from elementary-rocket-7360/airflow 
-e1aaa247f09d: Mounted from elementary-rocket-7360/airflow 
-c33dcb91918f: Mounted from elementary-rocket-7360/airflow 
-1cb60be4a43a: Mounted from elementary-rocket-7360/airflow 
-3fc755cc03d0: Mounted from elementary-rocket-7360/airflow 
-e09740f41293: Mounted from elementary-rocket-7360/airflow 
-5c858070b896: Mounted from elementary-rocket-7360/airflow 
-95df7c26d7c5: Mounted from elementary-rocket-7360/airflow 
-77cae8ab23bf: Mounted from elementary-rocket-7360/airflow 
+e5b0f4e97557: Pushed
+e4f165f2c539: Pushed
+7ae85d63186e: Pushed
+3d6737106ee1: Pushed
+cc0e1283f9aa: Pushed
+7e57912de03a: Mounted from elementary-rocket-7360/airflow
+e1aaa247f09d: Mounted from elementary-rocket-7360/airflow
+c33dcb91918f: Mounted from elementary-rocket-7360/airflow
+1cb60be4a43a: Mounted from elementary-rocket-7360/airflow
+3fc755cc03d0: Mounted from elementary-rocket-7360/airflow
+e09740f41293: Mounted from elementary-rocket-7360/airflow
+5c858070b896: Mounted from elementary-rocket-7360/airflow
+95df7c26d7c5: Mounted from elementary-rocket-7360/airflow
+77cae8ab23bf: Mounted from elementary-rocket-7360/airflow
 deploy-1: digest: sha256:9e69b7b81efc95c3f024f7656646b523f5b611c1954d52be6dca203c888fc842 size: 3230
 Untagged: registry.democluster.astronomer-trials.com/dynamical-flare-3582/airflow:deploy-1
 Untagged: registry.democluster.astronomer-trials.com/dynamical-flare-3582/airflow@sha256:9e69b7b81efc95c3f024f7656646b523f5b611c1954d52be6dca203c888fc842
@@ -250,6 +250,6 @@ These views show logs and metrics (respectively) acosss all deployments running 
 
 ## 10. Start inviting Users
 
-Now that you've run through all of the functionality on Astronomer enterprise, you're ready to start inviting users! 
+Now that you've run through all of the functionality on Astronomer enterprise, you're ready to start inviting users!
 
-To change the authentication system, naviate to our [Auth Systems](https://www.astronomer.io/docs/ee-integrating-auth-systems/) doc.
+To change the authentication system, naviate to our [Auth Systems](https://www.astronomer.io/docs/enterprise/v0.13/manage-astronomer/integrate-auth-system/) doc.

--- a/enterprise/v0.13/01_get-started/02_faq.md
+++ b/enterprise/v0.13/01_get-started/02_faq.md
@@ -48,16 +48,16 @@ You can find a list of all components used by the platform in the [Astronomer Pl
 No. Astronomer makes use of Kubernetes cluster-level features (including K8s RBAC) by design. These features include creating / deleting namespaces, daemonsets, roles, cluster-roles, service-accounts, resource-quotas, limit-ranges, etc. Additionally, Astronomer dynamically creates new airflow instances in separate namespaces, which protects data engineer users from noisy neighbors.
 
 * Roles
-  * [Houston](https://github.com/astronomer/astronomer/blob/v0.10.3-fix.4/charts/astronomer/templates/houston/houston-bootstrap-role.yaml)
-  * [Prisma](https://github.com/astronomer/astronomer/blob/v0.10.3-fix.4/charts/astronomer/templates/prisma/prisma-bootstrap-role.yaml)
-  * [Kubed](https://github.com/astronomer/astronomer/blob/v0.10.3-fix.4/charts/kubed/templates/kubed-clusterrole.yaml)
-  * [NGINX](https://github.com/astronomer/astronomer/blob/v0.10.3-fix.4/charts/nginx/templates/nginx-role.yaml)
-  * [Commander](https://github.com/astronomer/astronomer/blob/v0.10.3-fix.4/charts/astronomer/templates/commander/commander-role.yaml)
-  * [Fluentd](https://github.com/astronomer/astronomer/blob/v0.10.3-fix.4/charts/fluentd/templates/fluentd-clusterrole.yaml)
-  * [Prometheus](https://github.com/astronomer/astronomer/blob/v0.10.3-fix.4/charts/prometheus/templates/prometheus-role.yaml)
-  * [Grafana](https://github.com/astronomer/astronomer/blob/v0.10.3-fix.4/charts/grafana/templates/grafana-bootstrap-role.yaml)
-  * [Kubestate](https://github.com/astronomer/astronomer/blob/v0.10.3-fix.4/charts/kube-state/templates/kube-state-role.yaml)
-  * [Tiller](https://github.com/astronomer/astronomer/blob/tiller-clusterrole/charts/astronomer/templates/commander/tiller-clusterrole.yaml)
+  * [Houston](https://github.com/astronomer/astronomer/blob/release-0.13/charts/astronomer/templates/houston/houston-bootstrap-role.yaml)
+  * [Prisma](https://github.com/astronomer/astronomer/blob/release-0.13/charts/astronomer/templates/prisma/prisma-bootstrap-role.yaml)
+  * [Kubed](https://github.com/astronomer/astronomer/blob/release-0.13/charts/kubed/templates/kubed-clusterrole.yaml)
+  * [NGINX](https://github.com/astronomer/astronomer/blob/release-0.13/charts/nginx/templates/nginx-role.yaml)
+  * [Commander](https://github.com/astronomer/astronomer/blob/release-0.13/charts/astronomer/templates/commander/commander-role.yaml)
+  * [Fluentd](https://github.com/astronomer/astronomer/blob/release-0.13/charts/fluentd/templates/fluentd-clusterrole.yaml)
+  * [Prometheus](https://github.com/astronomer/astronomer/blob/release-0.13/charts/prometheus/templates/prometheus-role.yaml)
+  * [Grafana](https://github.com/astronomer/astronomer/blob/release-0.13/charts/grafana/templates/grafana-bootstrap-role.yaml)
+  * [Kubestate](https://github.com/astronomer/astronomer/blob/release-0.13/charts/kube-state/templates/kube-state-role.yaml)
+  * [Tiller](https://github.com/astronomer/astronomer/blob/release-0.13/charts/astronomer/templates/commander/commander-role.yaml)
 
 ### How can we restrict the application from getting full access?
 
@@ -85,13 +85,13 @@ You may have special requirements of your infrastructure such that you want to s
 
 ### How can we integrate with LDAP?
 
-See https://www.astronomer.io/docs/ee-integrating-auth-systems/
+See https://www.astronomer.io/docs/enterprise/v0.13/manage-astronomer/integrate-auth-system/
 
 ### How can we get multi-factor auth?
 
-Astronomer has a flexible [auth front end](https://www.astronomer.io/docs/ee-integrating-auth-systems/), with pre-built integrations for Google Auth, Okta, Auth0, and others.
+Astronomer has a flexible [auth front end](https://www.astronomer.io/docs/enterprise/v0.13/manage-astronomer/integrate-auth-system/), with pre-built integrations for Google Auth, Okta, Auth0, and others.
 
-If you choose to use Google Auth, we have [documentation available](https://www.astronomer.io/docs/ee-installation-google-oauth/). 
+If you choose to use Google Auth, we have [documentation available](https://www.astronomer.io/docs/ee-installation-google-oauth/).
 
 ### How can implement RBAC with this solution?
 

--- a/enterprise/v0.13/03_install/01_aws/01_install-aws-standard.md
+++ b/enterprise/v0.13/03_install/01_aws/01_install-aws-standard.md
@@ -25,7 +25,7 @@ All Astronomer services will be tied to a base domain of your choice, under whic
 
 Once created, your Astronomer base domain will be linked to a variety of sub-services that your users will access via the internet to manage, monitor and run Airflow on the platform.
 
-For the base domain `astro.mydomain.com`, for example, here are some corresponding URLs that your users would be able to reach: 
+For the base domain `astro.mydomain.com`, for example, here are some corresponding URLs that your users would be able to reach:
 
 * Astronomer UI: `app.astro.mydomain.com`
 * Airflow Deployments: `deployments.astro.mydomain.com/uniquely-generated-airflow-name/airflow`
@@ -38,7 +38,7 @@ For the full list of subdomains you need a certificate for, read below.
 
 To proceed with the installation, you'll need to spin up an [EKS Control Plane](https://aws.amazon.com/eks/) as well as worker nodes in your Kubernetes cluster by following [this AWS guide](https://docs.aws.amazon.com/eks/latest/userguide/getting-started.html).
 
-EKS is built off of Amazon's pre-existing EC2 service, so you can manage your Kubernetes nodes the same way you would manage your EC2 nodes. 
+EKS is built off of Amazon's pre-existing EC2 service, so you can manage your Kubernetes nodes the same way you would manage your EC2 nodes.
 
 As you follow the guide linked above, keep in mind:
 * Astronomer supports Kubernetes versions 1.14 and 1.15 (support for 1.16 coming soon).
@@ -169,7 +169,7 @@ nginx:
 
 #################################
 ### SMTP configuration
-#################################  
+#################################
 
 astronomer:
   houston:
@@ -177,7 +177,7 @@ astronomer:
       email:
         enabled: true
         smtpUrl: YOUR_URI_HERE
-``` 
+```
 
 SMTP is required and will allow users to send and accept email invites to Astronomer. The SMTP URI will take the following form:
 
@@ -188,7 +188,7 @@ smtpUrl: smtps://USERNAME:PW@HOST/?pool=true
 > **Note:** If you are using Amazon SES, your URL will look like the following:
 `smtpUrl: smtp://USERNAME:PW@HOST/?requireTLS=true`. If there are `/` or other escape characters in your username or password, you may need to [URL encode](https://www.urlencoder.org/) those characters.
 
-For more insight into how you might be able to customize Astronomer for your team, refer to step 12 at the bottom of this guide. 
+For more insight into how you might be able to customize Astronomer for your team, refer to step 12 at the bottom of this guide.
 
 ## 7. Install Astronomer
 
@@ -203,7 +203,7 @@ $ helm repo add astronomer https://helm.astronomer.io/
 $ helm install astronomer -f config.yaml --version=0.15.0 astronomer/astronomer --namespace astronomer
 ```
 
-This will generate a set of Kubernetes pods that will power the individual services required to run our platform, including the Astronomer UI, our Houston API, etc. 
+This will generate a set of Kubernetes pods that will power the individual services required to run our platform, including the Astronomer UI, our Houston API, etc.
 
 
 ## 8. Verify Pods are Up
@@ -263,7 +263,7 @@ If you are seeing issues here, check out our [guide on debugging your installati
 
 ## 9. Configure DNS
 
-Now that you've successfully installed Astronomer, a new Elastic Load Balancer (ELB) will have spun up in your AWS account. This ELB routes incoming traffic to our NGINX ingress controller.  
+Now that you've successfully installed Astronomer, a new Elastic Load Balancer (ELB) will have spun up in your AWS account. This ELB routes incoming traffic to our NGINX ingress controller.
 
 Run `kubectl get svc -n astronomer` to view your ELB's CNAME, located under the `EXTERNAL-IP` column for the `astronomer-nginx` service.
 
@@ -341,7 +341,7 @@ docker login registry.BASEDOMAIN -u _ p <token>
 
 To help you make the most of Astronomer Enterprise, take note of the following resources:
 
-* [Integrating an Auth System](https://www.astronomer.io/docs/ee-integrating-auth-system/)
+* [Integrating an Auth System](https://www.astronomer.io/docs/enterprise/v0.13/manage-astronomer/integrate-auth-system/)
 * [Configuring Platform Resources](https://www.astronomer.io/docs/ee-configuring-resources/)
 * [Managing Users on Astronomer Enterprise](https://www.astronomer.io/docs/ee-managing-users/)
 

--- a/enterprise/v0.13/03_install/02_gcp/01_install-gcp-standard.md
+++ b/enterprise/v0.13/03_install/02_gcp/01_install-gcp-standard.md
@@ -186,7 +186,7 @@ install.BASEDOMAIN
 
 ```
 
-You can also use a wildcard cert for yourdomain (e.g. `*.astro.BASEDOMAIN.com`). 
+You can also use a wildcard cert for yourdomain (e.g. `*.astro.BASEDOMAIN.com`).
 **Note:** You cannot use a self-signed certificate.
 
 
@@ -292,7 +292,7 @@ nginx:
 
 #################################
 ### SMTP configuration
-#################################  
+#################################
 
 astronomer:
   houston:
@@ -308,7 +308,7 @@ Note - the SMTP URI will take the form:
 smtpUrl: smtps://USERNAME:PW@HOST/?pool=true
 ```
 
-Check out our `Customizing Your Install` section for guidance on setting an [auth system](https://www.astronomer.io/docs/ee-integrating-auth-system/) and [resource requests(https://www.astronomer.io/docs/ee-configuring-resources/) in this `config.yaml`.
+Check out our `Customizing Your Install` section for guidance on setting an [auth system](https://www.astronomer.io/docs/enterprise/v0.13/manage-astronomer/integrate-auth-system/) and [resource requests(https://www.astronomer.io/docs/ee-configuring-resources/) in this `config.yaml`.
 
 ## 8. Install Astronomer
 
@@ -365,7 +365,7 @@ If you are seeing issues here, check out our [guide on debugging your installati
 
 Go to app.BASEDOMAIN to see the Astronomer UI.
 
-## 11. Verify SSL  
+## 11. Verify SSL
 
 To make sure that the certs were accepted, log into the platform and head to `app.BASEDOMAIN/token` and run:
 

--- a/enterprise/v0.13/03_install/03_azure/01_install-azure-standard.md
+++ b/enterprise/v0.13/03_install/03_azure/01_install-azure-standard.md
@@ -256,7 +256,7 @@ nginx:
 
 #################################
 ## SMTP configuration
-#################################  
+#################################
 
 astronomer:
   houston:
@@ -277,7 +277,7 @@ smtpUrl: smtps://USERNAME:PW@HOST/?pool=true
 $ helm install -f config.yaml . --namespace <my-namespace>
 ```
 
-Check out our `Customizing Your Install` section for guidance on setting an [auth system](https://www.astronomer.io/docs/ee-integrating-auth-system/) and [resource requests(https://www.astronomer.io/docs/ee-configuring-resources/) in this `config.yaml`.
+Check out our `Customizing Your Install` section for guidance on setting an [auth system](https://www.astronomer.io/docs/enterprise/v0.13/manage-astronomer/integrate-auth-system/) and [resource requests(https://www.astronomer.io/docs/ee-configuring-resources/) in this `config.yaml`.
 
 ## 10. Verify all pods are up
 

--- a/enterprise/v0.13/04_deploy/02_deploy-code.md
+++ b/enterprise/v0.13/04_deploy/02_deploy-code.md
@@ -15,7 +15,7 @@ In order to push up code to a deployment on Astronomer, you must have:
 
 ### Create a Deployment
 
-To create a deployment on Astronomer, log into the Astronomer UI on either: 
+To create a deployment on Astronomer, log into the Astronomer UI on either:
 - Astronomer Cloud
 - Your own domain on Astronomer Enterprise (`app.BASEDOMAIN`)
 
@@ -31,7 +31,7 @@ To finish creating your Deployment, you'll have to:
 - Pick an Airflow Executor (Celery or Local)
 - Set Initial Resources
 
-![New Deployment Config](https://assets2.astronomer.io/main/docs/deploying-code/v0.15-new_deployment-config.png)
+![New Deployment Config](https://assets2.astronomer.io/main/docs/deploying-code/V0.15-new_deployment-config.png)
 
 ### Deployment Dashboard
 
@@ -98,8 +98,8 @@ astro workspace switch [UUID]
 
 ```
 astro deployment list
- NAME           RELEASE NAME                 ASTRO      DEPLOYMENT ID                            
- demo_cluster     infrared-photon-7780     v0.7.5     c2436025-d501-4944-9c29-19ca61e7f359  
+ NAME           RELEASE NAME                 ASTRO      DEPLOYMENT ID
+ demo_cluster     infrared-photon-7780     v0.7.5     c2436025-d501-4944-9c29-19ca61e7f359
 ```
 
 ### Deploy
@@ -138,7 +138,7 @@ This is largely dependent on personal preference and your particular use case.
 
 ### Workspace Level
 
-At a Workspace level, we recommend having 1 Astronomer Workspace per team of Airflow users. That way, anyone on each team has access to the same set of deployments under that Workspace (RBAC will soon allow you to adjust that access at a deployment level if you'd like). 
+At a Workspace level, we recommend having 1 Astronomer Workspace per team of Airflow users. That way, anyone on each team has access to the same set of deployments under that Workspace (RBAC will soon allow you to adjust that access at a deployment level if you'd like).
 
 ### Deployment Level
 

--- a/enterprise/v0.13/04_deploy/06_ci-cd.md
+++ b/enterprise/v0.13/04_deploy/06_ci-cd.md
@@ -147,7 +147,7 @@ Example:
 docker build -t registry.${BASE_DOMAIN}/${RELEASE_NAME}/airflow:ci-${DRONE_BUILD_NUMBER} .
 ```
 
-If you would like to see a more complete working example please visit our [full example using Drone-CI](https://github.com/astronomer/airflow-example-dags/blob/master/.drone.yml).
+If you would like to see a more complete working example please visit our [full example using Drone-CI](https://github.com/astronomer/airflow-example-dags/blob/main/.drone.yml).
 
 ### Configure Your CI/CD Pipeline
 
@@ -330,7 +330,7 @@ on: [push]
 
 jobs:
   build:
-    runs-on: ubuntu-latest    
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
     - name: Publish to Astronomer.io

--- a/enterprise/v0.13/05_customize-airflow/04_airflow-alerts.md
+++ b/enterprise/v0.13/05_customize-airflow/04_airflow-alerts.md
@@ -27,9 +27,9 @@ You will need fill out some boilerplate survey information, but it's a quick set
 
 A new account will be given 40k emails for the first 30 days and then 100 emails/day for free. As long as your DAGs are working properly, this should be more than enough for most use cases.
 
-After you create your account, you'll reach a view like below. 
+After you create your account, you'll reach a view like below.
 
-#### 2. Click on "Integrate using our Web API or SMTP relay"   
+#### 2. Click on "Integrate using our Web API or SMTP relay"
 ![Sendgrid Getting Started](https://assets2.astronomer.io/main/docs/emails/sendgrid_getting_started.png)
 
 #### 3. Choose the "Web API (recommended)" method
@@ -114,7 +114,7 @@ AIRFLOW__SMTP__SMTP_MAIL_FROM={ENTER_FROM_EMAIL_HERE}
 
 Email alerting set up via `email_on_failure` is handled at the task level. If a handful of your tasks fail for related reasons, you'll receive an individual email for each of those failures.
 
-If you're interested in limiting failure alerts to the DAG run level, you can instead pass `on_failure_callback` ([source](https://github.com/apache/airflow/blob/v1-10-stable/airflow/models.py#L3311)) directly in your DAG file to define a Python function that sends you an email denoting failure.
+If you're interested in limiting failure alerts to the DAG run level, you can instead pass `on_failure_callback` ([source](https://github.com/apache/airflow/blob/v1-10-stable/airflow/models/dag.py#L167)) directly in your DAG file to define a Python function that sends you an email denoting failure.
 
 ```
  :param on_failure_callback: A function to be called when a DagRun of this dag fails.

--- a/enterprise/v0.13/06_manage-astronomer/01_integrate-auth-system.md
+++ b/enterprise/v0.13/06_manage-astronomer/01_integrate-auth-system.md
@@ -4,7 +4,7 @@ navTitle: "Integrate an Auth System"
 description: "Plug your internal authentication server into your Astronomer platform instantiation."
 ---
 
-By default, the Astronomer platform allows you to authenticate using your Google or GitHub account. We provide the option to authenticate using any alternative providers that follow the [Open Id Connect protocol](https://openid.net/connect/) via [Implicit Flow](https://auth0.com/docs/flows/concepts/implicit),  including (but not limited to) [Auth0](https://auth0.com/), [Okta](https://okta.com), and [Microsoft Azure's Active Directory](https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-protocols-oidc). 
+By default, the Astronomer platform allows you to authenticate using your Google or GitHub account. We provide the option to authenticate using any alternative providers that follow the [Open Id Connect protocol](https://openid.net/connect/) via [Implicit Flow](https://auth0.com/docs/flows/concepts/implicit),  including (but not limited to) [Auth0](https://auth0.com/), [Okta](https://www.okta.com), and [Microsoft Azure's Active Directory](https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-protocols-oidc).
 
 ## Configuration
 

--- a/enterprise/v0.13/06_manage-astronomer/03_workspace-permissions.md
+++ b/enterprise/v0.13/06_manage-astronomer/03_workspace-permissions.md
@@ -6,7 +6,7 @@ description: "Manage user roles and permissions within a single Astronomer Works
 
 Astronomer v0.9 and beyond supports role based access control (RBAC), allowing you to configure varying levels of access across all Users within your Workspace.
 
-The Astronomer image comes bundled with an [astronomer-fab-security manager package](https://github.com/astronomer/astronomer-fab-securitymanager/blob/4950500a51755f5b3d1ca288089404bfbd5fba60/README.md_) that connects permissions between
+The Astronomer image comes bundled with an [astronomer-fab-security manager package](https://github.com/astronomer/astronomer-fab-securitymanager/blob/3067c0470dbb1a528d1e251fb45312d01989e6a4/README.md) that connects permissions between
 Houston (the Astronomer API) and Airflow's built-in RBAC.
 
 For details on how those levels of permission are defined and how to leverage them on both Astronomer and Airflow, read the guidelines below.

--- a/enterprise/v0.13/09_resources/01_release-notes.md
+++ b/enterprise/v0.13/09_resources/01_release-notes.md
@@ -32,7 +32,7 @@ For more details on this new feature, reference our ["Environment Variables" doc
 
 Astronomer v0.16 for Astronomer Enterprise users comes with support for Microsoft's [Active Directory Federation services (AD FS)](https://docs.microsoft.com/en-us/windows-server/identity/active-directory-federation-services), as an alternative authentication system.
 
-To learn more, reference ["Auth Systems on Astronomer"](https://www.astronomer.io/docs/ee-integrating-auth-systems/).
+To learn more, reference ["Auth Systems on Astronomer"](https://www.astronomer.io/docs/enterprise/v0.13/manage-astronomer/integrate-auth-system/).
 
 ### Bug Fixes and Improvements
 

--- a/enterprise/v0.14/01_get-started/01_quickstart.md
+++ b/enterprise/v0.14/01_get-started/01_quickstart.md
@@ -153,12 +153,12 @@ Successfully tagged hello-astro_fc483c/airflow:latest
 Creating network "helloastrofc483c_airflow" with driver "bridge"
 Creating volume "helloastrofc483c_postgres_data" with driver "local"
 Creating volume "helloastrofc483c_airflow_logs" with driver "local"
-INFO[0015] [0/3] [postgres]: Starting                   
-INFO[0015] [1/3] [postgres]: Started                    
-INFO[0015] [1/3] [scheduler]: Starting                  
-INFO[0016] [2/3] [scheduler]: Started                   
-INFO[0016] [2/3] [webserver]: Starting                  
-INFO[0016] [3/3] [webserver]: Started                   
+INFO[0015] [0/3] [postgres]: Starting
+INFO[0015] [1/3] [postgres]: Started
+INFO[0015] [1/3] [scheduler]: Starting
+INFO[0016] [2/3] [scheduler]: Started
+INFO[0016] [2/3] [webserver]: Starting
+INFO[0016] [3/3] [webserver]: Started
 Airflow Webserver: http://localhost:8080
 Postgres Database: localhost:5432/postgres
 The default credentials are admin:admin
@@ -181,11 +181,11 @@ Once authenticated, run:
 
 ```
 /hello-astro$ astro deploy
-Authenticated to democluster.astronomer-trials.com 
+Authenticated to democluster.astronomer-trials.com
 
 Select which airflow deployment you want to deploy to:
- #     LABEL     DEPLOYMENT NAME          WORKSPACE     DEPLOYMENT ID                 
- 1     Dev       dynamical-flare-3582     ETLs          ck8g10xxc1zfq0966xlefcpxu     
+ #     LABEL     DEPLOYMENT NAME          WORKSPACE     DEPLOYMENT ID
+ 1     Dev       dynamical-flare-3582     ETLs          ck8g10xxc1zfq0966xlefcpxu
 
 > 1
 Deploying: dynamical-flare-3582
@@ -207,20 +207,20 @@ Successfully built d6e82b576ce5
 Successfully tagged dynamical-flare-3582/airflow:latest
 Pushing image to Astronomer registry
 The push refers to repository [registry.democluster.astronomer-trials.com/dynamical-flare-3582/airflow]
-e5b0f4e97557: Pushed 
-e4f165f2c539: Pushed 
-7ae85d63186e: Pushed 
-3d6737106ee1: Pushed 
-cc0e1283f9aa: Pushed 
-7e57912de03a: Mounted from elementary-rocket-7360/airflow 
-e1aaa247f09d: Mounted from elementary-rocket-7360/airflow 
-c33dcb91918f: Mounted from elementary-rocket-7360/airflow 
-1cb60be4a43a: Mounted from elementary-rocket-7360/airflow 
-3fc755cc03d0: Mounted from elementary-rocket-7360/airflow 
-e09740f41293: Mounted from elementary-rocket-7360/airflow 
-5c858070b896: Mounted from elementary-rocket-7360/airflow 
-95df7c26d7c5: Mounted from elementary-rocket-7360/airflow 
-77cae8ab23bf: Mounted from elementary-rocket-7360/airflow 
+e5b0f4e97557: Pushed
+e4f165f2c539: Pushed
+7ae85d63186e: Pushed
+3d6737106ee1: Pushed
+cc0e1283f9aa: Pushed
+7e57912de03a: Mounted from elementary-rocket-7360/airflow
+e1aaa247f09d: Mounted from elementary-rocket-7360/airflow
+c33dcb91918f: Mounted from elementary-rocket-7360/airflow
+1cb60be4a43a: Mounted from elementary-rocket-7360/airflow
+3fc755cc03d0: Mounted from elementary-rocket-7360/airflow
+e09740f41293: Mounted from elementary-rocket-7360/airflow
+5c858070b896: Mounted from elementary-rocket-7360/airflow
+95df7c26d7c5: Mounted from elementary-rocket-7360/airflow
+77cae8ab23bf: Mounted from elementary-rocket-7360/airflow
 deploy-1: digest: sha256:9e69b7b81efc95c3f024f7656646b523f5b611c1954d52be6dca203c888fc842 size: 3230
 Untagged: registry.democluster.astronomer-trials.com/dynamical-flare-3582/airflow:deploy-1
 Untagged: registry.democluster.astronomer-trials.com/dynamical-flare-3582/airflow@sha256:9e69b7b81efc95c3f024f7656646b523f5b611c1954d52be6dca203c888fc842
@@ -250,6 +250,6 @@ These views show logs and metrics (respectively) acosss all deployments running 
 
 ## 10. Start inviting Users
 
-Now that you've run through all of the functionality on Astronomer enterprise, you're ready to start inviting users! 
+Now that you've run through all of the functionality on Astronomer enterprise, you're ready to start inviting users!
 
-To change the authentication system, naviate to our [Auth Systems](https://www.astronomer.io/docs/ee-integrating-auth-systems/) doc.
+To change the authentication system, naviate to our [Auth Systems](https://www.astronomer.io/docs/enterprise/v0.14/manage-astronomer/integrate-auth-system/) doc.

--- a/enterprise/v0.14/01_get-started/02_faq.md
+++ b/enterprise/v0.14/01_get-started/02_faq.md
@@ -48,16 +48,16 @@ You can find a list of all components used by the platform in the [Astronomer Pl
 No. Astronomer makes use of Kubernetes cluster-level features (including K8s RBAC) by design. These features include creating / deleting namespaces, daemonsets, roles, cluster-roles, service-accounts, resource-quotas, limit-ranges, etc. Additionally, Astronomer dynamically creates new airflow instances in separate namespaces, which protects data engineer users from noisy neighbors.
 
 * Roles
-  * [Houston](https://github.com/astronomer/astronomer/blob/v0.10.3-fix.4/charts/astronomer/templates/houston/houston-bootstrap-role.yaml)
-  * [Prisma](https://github.com/astronomer/astronomer/blob/v0.10.3-fix.4/charts/astronomer/templates/prisma/prisma-bootstrap-role.yaml)
-  * [Kubed](https://github.com/astronomer/astronomer/blob/v0.10.3-fix.4/charts/kubed/templates/kubed-clusterrole.yaml)
-  * [NGINX](https://github.com/astronomer/astronomer/blob/v0.10.3-fix.4/charts/nginx/templates/nginx-role.yaml)
-  * [Commander](https://github.com/astronomer/astronomer/blob/v0.10.3-fix.4/charts/astronomer/templates/commander/commander-role.yaml)
-  * [Fluentd](https://github.com/astronomer/astronomer/blob/v0.10.3-fix.4/charts/fluentd/templates/fluentd-clusterrole.yaml)
-  * [Prometheus](https://github.com/astronomer/astronomer/blob/v0.10.3-fix.4/charts/prometheus/templates/prometheus-role.yaml)
-  * [Grafana](https://github.com/astronomer/astronomer/blob/v0.10.3-fix.4/charts/grafana/templates/grafana-bootstrap-role.yaml)
-  * [Kubestate](https://github.com/astronomer/astronomer/blob/v0.10.3-fix.4/charts/kube-state/templates/kube-state-role.yaml)
-  * [Tiller](https://github.com/astronomer/astronomer/blob/tiller-clusterrole/charts/astronomer/templates/commander/tiller-clusterrole.yaml)
+  * [Houston](https://github.com/astronomer/astronomer/blob/release-0.14/charts/astronomer/templates/houston/houston-bootstrap-role.yaml)
+  * [Prisma](https://github.com/astronomer/astronomer/blob/release-0.14/charts/astronomer/templates/prisma/prisma-bootstrap-role.yaml)
+  * [Kubed](https://github.com/astronomer/astronomer/blob/release-0.14/charts/kubed/templates/kubed-clusterrole.yaml)
+  * [NGINX](https://github.com/astronomer/astronomer/blob/release-0.14/charts/nginx/templates/nginx-role.yaml)
+  * [Commander](https://github.com/astronomer/astronomer/blob/release-0.14/charts/astronomer/templates/commander/commander-role.yaml)
+  * [Fluentd](https://github.com/astronomer/astronomer/blob/release-0.14/charts/fluentd/templates/fluentd-clusterrole.yaml)
+  * [Prometheus](https://github.com/astronomer/astronomer/blob/release-0.14/charts/prometheus/templates/prometheus-role.yaml)
+  * [Grafana](https://github.com/astronomer/astronomer/blob/release-0.14/charts/grafana/templates/grafana-bootstrap-role.yaml)
+  * [Kubestate](https://github.com/astronomer/astronomer/blob/release-0.14/charts/kube-state/templates/kube-state-role.yaml)
+  * [Tiller](https://github.com/astronomer/astronomer/blob/release-0.14/charts/astronomer/templates/commander/commander-role.yaml)
 
 ### How can we restrict the application from getting full access?
 
@@ -85,13 +85,13 @@ You may have special requirements of your infrastructure such that you want to s
 
 ### How can we integrate with LDAP?
 
-See https://www.astronomer.io/docs/ee-integrating-auth-systems/
+See https://www.astronomer.io/docs/enterprise/v0.14/manage-astronomer/integrate-auth-system/
 
 ### How can we get multi-factor auth?
 
-Astronomer has a flexible [auth front end](https://www.astronomer.io/docs/ee-integrating-auth-systems/), with pre-built integrations for Google Auth, Okta, Auth0, and others.
+Astronomer has a flexible [auth front end](https://www.astronomer.io/docs/enterprise/v0.14/manage-astronomer/integrate-auth-system/), with pre-built integrations for Google Auth, Okta, Auth0, and others.
 
-If you choose to use Google Auth, we have [documentation available](https://www.astronomer.io/docs/ee-installation-google-oauth/). 
+If you choose to use Google Auth, we have [documentation available](https://www.astronomer.io/docs/ee-installation-google-oauth/).
 
 ### How can implement RBAC with this solution?
 

--- a/enterprise/v0.14/03_install/01_aws/01_install-aws-standard.md
+++ b/enterprise/v0.14/03_install/01_aws/01_install-aws-standard.md
@@ -25,7 +25,7 @@ All Astronomer services will be tied to a base domain of your choice, under whic
 
 Once created, your Astronomer base domain will be linked to a variety of sub-services that your users will access via the internet to manage, monitor and run Airflow on the platform.
 
-For the base domain `astro.mydomain.com`, for example, here are some corresponding URLs that your users would be able to reach: 
+For the base domain `astro.mydomain.com`, for example, here are some corresponding URLs that your users would be able to reach:
 
 * Astronomer UI: `app.astro.mydomain.com`
 * Airflow Deployments: `deployments.astro.mydomain.com/uniquely-generated-airflow-name/airflow`
@@ -38,7 +38,7 @@ For the full list of subdomains you need a certificate for, read below.
 
 To proceed with the installation, you'll need to spin up an [EKS Control Plane](https://aws.amazon.com/eks/) as well as worker nodes in your Kubernetes cluster by following [this AWS guide](https://docs.aws.amazon.com/eks/latest/userguide/getting-started.html).
 
-EKS is built off of Amazon's pre-existing EC2 service, so you can manage your Kubernetes nodes the same way you would manage your EC2 nodes. 
+EKS is built off of Amazon's pre-existing EC2 service, so you can manage your Kubernetes nodes the same way you would manage your EC2 nodes.
 
 As you follow the guide linked above, keep in mind:
 * Astronomer supports Kubernetes versions 1.14 and 1.15 (support for 1.16 coming soon).
@@ -169,7 +169,7 @@ nginx:
 
 #################################
 ### SMTP configuration
-#################################  
+#################################
 
 astronomer:
   houston:
@@ -177,7 +177,7 @@ astronomer:
       email:
         enabled: true
         smtpUrl: YOUR_URI_HERE
-``` 
+```
 
 SMTP is required and will allow users to send and accept email invites to Astronomer. The SMTP URI will take the following form:
 
@@ -188,7 +188,7 @@ smtpUrl: smtps://USERNAME:PW@HOST/?pool=true
 > **Note:** If you are using Amazon SES, your URL will look like the following:
 `smtpUrl: smtp://USERNAME:PW@HOST/?requireTLS=true`. If there are `/` or other escape characters in your username or password, you may need to [URL encode](https://www.urlencoder.org/) those characters.
 
-For more insight into how you might be able to customize Astronomer for your team, refer to step 12 at the bottom of this guide. 
+For more insight into how you might be able to customize Astronomer for your team, refer to step 12 at the bottom of this guide.
 
 ## 7. Install Astronomer
 
@@ -203,7 +203,7 @@ $ helm repo add astronomer https://helm.astronomer.io/
 $ helm install astronomer -f config.yaml --version=0.15.0 astronomer/astronomer --namespace astronomer
 ```
 
-This will generate a set of Kubernetes pods that will power the individual services required to run our platform, including the Astronomer UI, our Houston API, etc. 
+This will generate a set of Kubernetes pods that will power the individual services required to run our platform, including the Astronomer UI, our Houston API, etc.
 
 
 ## 8. Verify Pods are Up
@@ -263,7 +263,7 @@ If you are seeing issues here, check out our [guide on debugging your installati
 
 ## 9. Configure DNS
 
-Now that you've successfully installed Astronomer, a new Elastic Load Balancer (ELB) will have spun up in your AWS account. This ELB routes incoming traffic to our NGINX ingress controller.  
+Now that you've successfully installed Astronomer, a new Elastic Load Balancer (ELB) will have spun up in your AWS account. This ELB routes incoming traffic to our NGINX ingress controller.
 
 Run `kubectl get svc -n astronomer` to view your ELB's CNAME, located under the `EXTERNAL-IP` column for the `astronomer-nginx` service.
 
@@ -341,7 +341,7 @@ docker login registry.BASEDOMAIN -u _ p <token>
 
 To help you make the most of Astronomer Enterprise, take note of the following resources:
 
-* [Integrating an Auth System](https://www.astronomer.io/docs/ee-integrating-auth-system/)
+* [Integrating an Auth System](https://www.astronomer.io/docs/enterprise/v0.14/manage-astronomer/integrate-auth-system/)
 * [Configuring Platform Resources](https://www.astronomer.io/docs/ee-configuring-resources/)
 * [Managing Users on Astronomer Enterprise](https://www.astronomer.io/docs/ee-managing-users/)
 

--- a/enterprise/v0.14/03_install/02_gcp/01_install-gcp-standard.md
+++ b/enterprise/v0.14/03_install/02_gcp/01_install-gcp-standard.md
@@ -186,7 +186,7 @@ install.BASEDOMAIN
 
 ```
 
-You can also use a wildcard cert for yourdomain (e.g. `*.astro.BASEDOMAIN.com`). 
+You can also use a wildcard cert for yourdomain (e.g. `*.astro.BASEDOMAIN.com`).
 **Note:** You cannot use a self-signed certificate.
 
 
@@ -292,7 +292,7 @@ nginx:
 
 #################################
 ### SMTP configuration
-#################################  
+#################################
 
 astronomer:
   houston:
@@ -308,7 +308,7 @@ Note - the SMTP URI will take the form:
 smtpUrl: smtps://USERNAME:PW@HOST/?pool=true
 ```
 
-Check out our `Customizing Your Install` section for guidance on setting an [auth system](https://www.astronomer.io/docs/ee-integrating-auth-system/) and [resource requests(https://www.astronomer.io/docs/ee-configuring-resources/) in this `config.yaml`.
+Check out our `Customizing Your Install` section for guidance on setting an [auth system](https://www.astronomer.io/docs/enterprise/v0.14/manage-astronomer/integrate-auth-system/) and [resource requests(https://www.astronomer.io/docs/ee-configuring-resources/) in this `config.yaml`.
 
 ## 8. Install Astronomer
 
@@ -365,7 +365,7 @@ If you are seeing issues here, check out our [guide on debugging your installati
 
 Go to app.BASEDOMAIN to see the Astronomer UI.
 
-## 11. Verify SSL  
+## 11. Verify SSL
 
 To make sure that the certs were accepted, log into the platform and head to `app.BASEDOMAIN/token` and run:
 

--- a/enterprise/v0.14/03_install/03_azure/01_install-azure-standard.md
+++ b/enterprise/v0.14/03_install/03_azure/01_install-azure-standard.md
@@ -256,7 +256,7 @@ nginx:
 
 #################################
 ## SMTP configuration
-#################################  
+#################################
 
 astronomer:
   houston:
@@ -277,7 +277,7 @@ smtpUrl: smtps://USERNAME:PW@HOST/?pool=true
 $ helm install -f config.yaml . --namespace <my-namespace>
 ```
 
-Check out our `Customizing Your Install` section for guidance on setting an [auth system](https://www.astronomer.io/docs/ee-integrating-auth-system/) and [resource requests(https://www.astronomer.io/docs/ee-configuring-resources/) in this `config.yaml`.
+Check out our `Customizing Your Install` section for guidance on setting an [auth system](https://www.astronomer.io/docs/enterprise/v0.14/manage-astronomer/integrate-auth-system/) and [resource requests(https://www.astronomer.io/docs/ee-configuring-resources/) in this `config.yaml`.
 
 ## 10. Verify all pods are up
 

--- a/enterprise/v0.14/04_deploy/02_deploy-code.md
+++ b/enterprise/v0.14/04_deploy/02_deploy-code.md
@@ -15,7 +15,7 @@ In order to push up code to a deployment on Astronomer, you must have:
 
 ### Create a Deployment
 
-To create a deployment on Astronomer, log into the Astronomer UI on either: 
+To create a deployment on Astronomer, log into the Astronomer UI on either:
 - Astronomer Cloud
 - Your own domain on Astronomer Enterprise (`app.BASEDOMAIN`)
 
@@ -31,7 +31,7 @@ To finish creating your Deployment, you'll have to:
 - Pick an Airflow Executor (Celery or Local)
 - Set Initial Resources
 
-![New Deployment Config](https://assets2.astronomer.io/main/docs/deploying-code/v0.15-new_deployment-config.png)
+![New Deployment Config](https://assets2.astronomer.io/main/docs/deploying-code/V0.15-new_deployment-config.png)
 
 ### Deployment Dashboard
 
@@ -98,8 +98,8 @@ astro workspace switch [UUID]
 
 ```
 astro deployment list
- NAME           RELEASE NAME                 ASTRO      DEPLOYMENT ID                            
- demo_cluster     infrared-photon-7780     v0.7.5     c2436025-d501-4944-9c29-19ca61e7f359  
+ NAME           RELEASE NAME                 ASTRO      DEPLOYMENT ID
+ demo_cluster     infrared-photon-7780     v0.7.5     c2436025-d501-4944-9c29-19ca61e7f359
 ```
 
 ### Deploy
@@ -138,7 +138,7 @@ This is largely dependent on personal preference and your particular use case.
 
 ### Workspace Level
 
-At a Workspace level, we recommend having 1 Astronomer Workspace per team of Airflow users. That way, anyone on each team has access to the same set of deployments under that Workspace (RBAC will soon allow you to adjust that access at a deployment level if you'd like). 
+At a Workspace level, we recommend having 1 Astronomer Workspace per team of Airflow users. That way, anyone on each team has access to the same set of deployments under that Workspace (RBAC will soon allow you to adjust that access at a deployment level if you'd like).
 
 ### Deployment Level
 

--- a/enterprise/v0.14/04_deploy/06_ci-cd.md
+++ b/enterprise/v0.14/04_deploy/06_ci-cd.md
@@ -147,7 +147,7 @@ Example:
 docker build -t registry.${BASE_DOMAIN}/${RELEASE_NAME}/airflow:ci-${DRONE_BUILD_NUMBER} .
 ```
 
-If you would like to see a more complete working example please visit our [full example using Drone-CI](https://github.com/astronomer/airflow-example-dags/blob/master/.drone.yml).
+If you would like to see a more complete working example please visit our [full example using Drone-CI](https://github.com/astronomer/airflow-example-dags/blob/main/.drone.yml).
 
 ### Configure Your CI/CD Pipeline
 
@@ -330,7 +330,7 @@ on: [push]
 
 jobs:
   build:
-    runs-on: ubuntu-latest    
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
     - name: Publish to Astronomer.io

--- a/enterprise/v0.14/05_customize-airflow/04_airflow-alerts.md
+++ b/enterprise/v0.14/05_customize-airflow/04_airflow-alerts.md
@@ -27,9 +27,9 @@ You will need fill out some boilerplate survey information, but it's a quick set
 
 A new account will be given 40k emails for the first 30 days and then 100 emails/day for free. As long as your DAGs are working properly, this should be more than enough for most use cases.
 
-After you create your account, you'll reach a view like below. 
+After you create your account, you'll reach a view like below.
 
-#### 2. Click on "Integrate using our Web API or SMTP relay"   
+#### 2. Click on "Integrate using our Web API or SMTP relay"
 ![Sendgrid Getting Started](https://assets2.astronomer.io/main/docs/emails/sendgrid_getting_started.png)
 
 #### 3. Choose the "Web API (recommended)" method
@@ -114,7 +114,7 @@ AIRFLOW__SMTP__SMTP_MAIL_FROM={ENTER_FROM_EMAIL_HERE}
 
 Email alerting set up via `email_on_failure` is handled at the task level. If a handful of your tasks fail for related reasons, you'll receive an individual email for each of those failures.
 
-If you're interested in limiting failure alerts to the DAG run level, you can instead pass `on_failure_callback` ([source](https://github.com/apache/airflow/blob/v1-10-stable/airflow/models.py#L3311)) directly in your DAG file to define a Python function that sends you an email denoting failure.
+If you're interested in limiting failure alerts to the DAG run level, you can instead pass `on_failure_callback` ([source](https://github.com/apache/airflow/blob/v1-10-stable/airflow/models/dag.py#L167)) directly in your DAG file to define a Python function that sends you an email denoting failure.
 
 ```
  :param on_failure_callback: A function to be called when a DagRun of this dag fails.

--- a/enterprise/v0.14/06_manage-astronomer/01_integrate-auth-system.md
+++ b/enterprise/v0.14/06_manage-astronomer/01_integrate-auth-system.md
@@ -4,7 +4,7 @@ navTitle: "Integrate an Auth System"
 description: "Plug your internal authentication server into your Astronomer platform instantiation."
 ---
 
-By default, the Astronomer platform allows you to authenticate using your Google or GitHub account. We provide the option to authenticate using any alternative providers that follow the [Open Id Connect protocol](https://openid.net/connect/) via [Implicit Flow](https://auth0.com/docs/flows/concepts/implicit),  including (but not limited to) [Auth0](https://auth0.com/), [Okta](https://okta.com), and [Microsoft Azure's Active Directory](https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-protocols-oidc). 
+By default, the Astronomer platform allows you to authenticate using your Google or GitHub account. We provide the option to authenticate using any alternative providers that follow the [Open Id Connect protocol](https://openid.net/connect/) via [Implicit Flow](https://auth0.com/docs/flows/concepts/implicit),  including (but not limited to) [Auth0](https://auth0.com/), [Okta](https://www.okta.com), and [Microsoft Azure's Active Directory](https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-protocols-oidc).
 
 ## Configuration
 

--- a/enterprise/v0.14/06_manage-astronomer/03_workspace-permissions.md
+++ b/enterprise/v0.14/06_manage-astronomer/03_workspace-permissions.md
@@ -6,7 +6,7 @@ description: "Manage user roles and permissions within a single Astronomer Works
 
 Astronomer v0.9 and beyond supports role based access control (RBAC), allowing you to configure varying levels of access across all Users within your Workspace.
 
-The Astronomer image comes bundled with an [astronomer-fab-security manager package](https://github.com/astronomer/astronomer-fab-securitymanager/blob/4950500a51755f5b3d1ca288089404bfbd5fba60/README.md_) that connects permissions between
+The Astronomer image comes bundled with an [astronomer-fab-security manager package](https://github.com/astronomer/astronomer-fab-securitymanager/blob/3067c0470dbb1a528d1e251fb45312d01989e6a4/README.md) that connects permissions between
 Houston (the Astronomer API) and Airflow's built-in RBAC.
 
 For details on how those levels of permission are defined and how to leverage them on both Astronomer and Airflow, read the guidelines below.

--- a/enterprise/v0.14/09_resources/01_release-notes.md
+++ b/enterprise/v0.14/09_resources/01_release-notes.md
@@ -32,7 +32,7 @@ For more details on this new feature, reference our ["Environment Variables" doc
 
 Astronomer v0.16 for Astronomer Enterprise users comes with support for Microsoft's [Active Directory Federation services (AD FS)](https://docs.microsoft.com/en-us/windows-server/identity/active-directory-federation-services), as an alternative authentication system.
 
-To learn more, reference ["Auth Systems on Astronomer"](https://www.astronomer.io/docs/ee-integrating-auth-systems/).
+To learn more, reference ["Auth Systems on Astronomer"](https://www.astronomer.io/docs/enterprise/v0.14/manage-astronomer/integrate-auth-system/).
 
 ### Bug Fixes and Improvements
 

--- a/enterprise/v0.15/01_get-started/01_quickstart.md
+++ b/enterprise/v0.15/01_get-started/01_quickstart.md
@@ -153,12 +153,12 @@ Successfully tagged hello-astro_fc483c/airflow:latest
 Creating network "helloastrofc483c_airflow" with driver "bridge"
 Creating volume "helloastrofc483c_postgres_data" with driver "local"
 Creating volume "helloastrofc483c_airflow_logs" with driver "local"
-INFO[0015] [0/3] [postgres]: Starting                   
-INFO[0015] [1/3] [postgres]: Started                    
-INFO[0015] [1/3] [scheduler]: Starting                  
-INFO[0016] [2/3] [scheduler]: Started                   
-INFO[0016] [2/3] [webserver]: Starting                  
-INFO[0016] [3/3] [webserver]: Started                   
+INFO[0015] [0/3] [postgres]: Starting
+INFO[0015] [1/3] [postgres]: Started
+INFO[0015] [1/3] [scheduler]: Starting
+INFO[0016] [2/3] [scheduler]: Started
+INFO[0016] [2/3] [webserver]: Starting
+INFO[0016] [3/3] [webserver]: Started
 Airflow Webserver: http://localhost:8080
 Postgres Database: localhost:5432/postgres
 The default credentials are admin:admin
@@ -181,11 +181,11 @@ Once authenticated, run:
 
 ```
 /hello-astro$ astro deploy
-Authenticated to democluster.astronomer-trials.com 
+Authenticated to democluster.astronomer-trials.com
 
 Select which airflow deployment you want to deploy to:
- #     LABEL     DEPLOYMENT NAME          WORKSPACE     DEPLOYMENT ID                 
- 1     Dev       dynamical-flare-3582     ETLs          ck8g10xxc1zfq0966xlefcpxu     
+ #     LABEL     DEPLOYMENT NAME          WORKSPACE     DEPLOYMENT ID
+ 1     Dev       dynamical-flare-3582     ETLs          ck8g10xxc1zfq0966xlefcpxu
 
 > 1
 Deploying: dynamical-flare-3582
@@ -207,20 +207,20 @@ Successfully built d6e82b576ce5
 Successfully tagged dynamical-flare-3582/airflow:latest
 Pushing image to Astronomer registry
 The push refers to repository [registry.democluster.astronomer-trials.com/dynamical-flare-3582/airflow]
-e5b0f4e97557: Pushed 
-e4f165f2c539: Pushed 
-7ae85d63186e: Pushed 
-3d6737106ee1: Pushed 
-cc0e1283f9aa: Pushed 
-7e57912de03a: Mounted from elementary-rocket-7360/airflow 
-e1aaa247f09d: Mounted from elementary-rocket-7360/airflow 
-c33dcb91918f: Mounted from elementary-rocket-7360/airflow 
-1cb60be4a43a: Mounted from elementary-rocket-7360/airflow 
-3fc755cc03d0: Mounted from elementary-rocket-7360/airflow 
-e09740f41293: Mounted from elementary-rocket-7360/airflow 
-5c858070b896: Mounted from elementary-rocket-7360/airflow 
-95df7c26d7c5: Mounted from elementary-rocket-7360/airflow 
-77cae8ab23bf: Mounted from elementary-rocket-7360/airflow 
+e5b0f4e97557: Pushed
+e4f165f2c539: Pushed
+7ae85d63186e: Pushed
+3d6737106ee1: Pushed
+cc0e1283f9aa: Pushed
+7e57912de03a: Mounted from elementary-rocket-7360/airflow
+e1aaa247f09d: Mounted from elementary-rocket-7360/airflow
+c33dcb91918f: Mounted from elementary-rocket-7360/airflow
+1cb60be4a43a: Mounted from elementary-rocket-7360/airflow
+3fc755cc03d0: Mounted from elementary-rocket-7360/airflow
+e09740f41293: Mounted from elementary-rocket-7360/airflow
+5c858070b896: Mounted from elementary-rocket-7360/airflow
+95df7c26d7c5: Mounted from elementary-rocket-7360/airflow
+77cae8ab23bf: Mounted from elementary-rocket-7360/airflow
 deploy-1: digest: sha256:9e69b7b81efc95c3f024f7656646b523f5b611c1954d52be6dca203c888fc842 size: 3230
 Untagged: registry.democluster.astronomer-trials.com/dynamical-flare-3582/airflow:deploy-1
 Untagged: registry.democluster.astronomer-trials.com/dynamical-flare-3582/airflow@sha256:9e69b7b81efc95c3f024f7656646b523f5b611c1954d52be6dca203c888fc842
@@ -250,6 +250,6 @@ These views show logs and metrics (respectively) acosss all deployments running 
 
 ## 10. Start inviting Users
 
-Now that you've run through all of the functionality on Astronomer enterprise, you're ready to start inviting users! 
+Now that you've run through all of the functionality on Astronomer enterprise, you're ready to start inviting users!
 
-To change the authentication system, naviate to our [Auth Systems](https://www.astronomer.io/docs/ee-integrating-auth-systems/) doc.
+To change the authentication system, naviate to our [Auth Systems](https://www.astronomer.io/docs/enterprise/v0.15/manage-astronomer/integrate-auth-system/) doc.

--- a/enterprise/v0.15/01_get-started/02_faq.md
+++ b/enterprise/v0.15/01_get-started/02_faq.md
@@ -48,16 +48,16 @@ You can find a list of all components used by the platform in the [Astronomer Pl
 No. Astronomer makes use of Kubernetes cluster-level features (including K8s RBAC) by design. These features include creating / deleting namespaces, daemonsets, roles, cluster-roles, service-accounts, resource-quotas, limit-ranges, etc. Additionally, Astronomer dynamically creates new airflow instances in separate namespaces, which protects data engineer users from noisy neighbors.
 
 * Roles
-  * [Houston](https://github.com/astronomer/astronomer/blob/v0.10.3-fix.4/charts/astronomer/templates/houston/houston-bootstrap-role.yaml)
-  * [Prisma](https://github.com/astronomer/astronomer/blob/v0.10.3-fix.4/charts/astronomer/templates/prisma/prisma-bootstrap-role.yaml)
-  * [Kubed](https://github.com/astronomer/astronomer/blob/v0.10.3-fix.4/charts/kubed/templates/kubed-clusterrole.yaml)
-  * [NGINX](https://github.com/astronomer/astronomer/blob/v0.10.3-fix.4/charts/nginx/templates/nginx-role.yaml)
-  * [Commander](https://github.com/astronomer/astronomer/blob/v0.10.3-fix.4/charts/astronomer/templates/commander/commander-role.yaml)
-  * [Fluentd](https://github.com/astronomer/astronomer/blob/v0.10.3-fix.4/charts/fluentd/templates/fluentd-clusterrole.yaml)
-  * [Prometheus](https://github.com/astronomer/astronomer/blob/v0.10.3-fix.4/charts/prometheus/templates/prometheus-role.yaml)
-  * [Grafana](https://github.com/astronomer/astronomer/blob/v0.10.3-fix.4/charts/grafana/templates/grafana-bootstrap-role.yaml)
-  * [Kubestate](https://github.com/astronomer/astronomer/blob/v0.10.3-fix.4/charts/kube-state/templates/kube-state-role.yaml)
-  * [Tiller](https://github.com/astronomer/astronomer/blob/tiller-clusterrole/charts/astronomer/templates/commander/tiller-clusterrole.yaml)
+  * [Houston](https://github.com/astronomer/astronomer/blob/release-0.15/charts/astronomer/templates/houston/houston-bootstrap-role.yaml)
+  * [Prisma](https://github.com/astronomer/astronomer/blob/release-0.15/charts/astronomer/templates/prisma/prisma-bootstrap-role.yaml)
+  * [Kubed](https://github.com/astronomer/astronomer/blob/release-0.15/charts/kubed/templates/kubed-clusterrole.yaml)
+  * [NGINX](https://github.com/astronomer/astronomer/blob/release-0.15/charts/nginx/templates/nginx-role.yaml)
+  * [Commander](https://github.com/astronomer/astronomer/blob/release-0.15/charts/astronomer/templates/commander/commander-role.yaml)
+  * [Fluentd](https://github.com/astronomer/astronomer/blob/release-0.15/charts/fluentd/templates/fluentd-clusterrole.yaml)
+  * [Prometheus](https://github.com/astronomer/astronomer/blob/release-0.15/charts/prometheus/templates/prometheus-role.yaml)
+  * [Grafana](https://github.com/astronomer/astronomer/blob/release-0.15/charts/grafana/templates/grafana-bootstrap-role.yaml)
+  * [Kubestate](https://github.com/astronomer/astronomer/blob/release-0.15/charts/kube-state/templates/kube-state-role.yaml)
+  * [Tiller](https://github.com/astronomer/astronomer/blob/release-0.15/charts/astronomer/templates/commander/commander-role.yaml)
 
 ### How can we restrict the application from getting full access?
 
@@ -85,13 +85,13 @@ You may have special requirements of your infrastructure such that you want to s
 
 ### How can we integrate with LDAP?
 
-See https://www.astronomer.io/docs/ee-integrating-auth-systems/
+See https://www.astronomer.io/docs/enterprise/v0.15/manage-astronomer/integrate-auth-system/
 
 ### How can we get multi-factor auth?
 
-Astronomer has a flexible [auth front end](https://www.astronomer.io/docs/ee-integrating-auth-systems/), with pre-built integrations for Google Auth, Okta, Auth0, and others.
+Astronomer has a flexible [auth front end](https://www.astronomer.io/docs/enterprise/v0.15/manage-astronomer/integrate-auth-system/), with pre-built integrations for Google Auth, Okta, Auth0, and others.
 
-If you choose to use Google Auth, we have [documentation available](https://www.astronomer.io/docs/ee-installation-google-oauth/). 
+If you choose to use Google Auth, we have [documentation available](https://www.astronomer.io/docs/ee-installation-google-oauth/).
 
 ### How can implement RBAC with this solution?
 

--- a/enterprise/v0.15/03_install/01_aws/01_install-aws-standard.md
+++ b/enterprise/v0.15/03_install/01_aws/01_install-aws-standard.md
@@ -25,7 +25,7 @@ All Astronomer services will be tied to a base domain of your choice, under whic
 
 Once created, your Astronomer base domain will be linked to a variety of sub-services that your users will access via the internet to manage, monitor and run Airflow on the platform.
 
-For the base domain `astro.mydomain.com`, for example, here are some corresponding URLs that your users would be able to reach: 
+For the base domain `astro.mydomain.com`, for example, here are some corresponding URLs that your users would be able to reach:
 
 * Astronomer UI: `app.astro.mydomain.com`
 * Airflow Deployments: `deployments.astro.mydomain.com/uniquely-generated-airflow-name/airflow`
@@ -38,7 +38,7 @@ For the full list of subdomains you need a certificate for, read below.
 
 To proceed with the installation, you'll need to spin up an [EKS Control Plane](https://aws.amazon.com/eks/) as well as worker nodes in your Kubernetes cluster by following [this AWS guide](https://docs.aws.amazon.com/eks/latest/userguide/getting-started.html).
 
-EKS is built off of Amazon's pre-existing EC2 service, so you can manage your Kubernetes nodes the same way you would manage your EC2 nodes. 
+EKS is built off of Amazon's pre-existing EC2 service, so you can manage your Kubernetes nodes the same way you would manage your EC2 nodes.
 
 As you follow the guide linked above, keep in mind:
 * Astronomer supports Kubernetes versions 1.14 and 1.15 (support for 1.16 coming soon).
@@ -169,7 +169,7 @@ nginx:
 
 #################################
 ### SMTP configuration
-#################################  
+#################################
 
 astronomer:
   houston:
@@ -177,7 +177,7 @@ astronomer:
       email:
         enabled: true
         smtpUrl: YOUR_URI_HERE
-``` 
+```
 
 SMTP is required and will allow users to send and accept email invites to Astronomer. The SMTP URI will take the following form:
 
@@ -188,7 +188,7 @@ smtpUrl: smtps://USERNAME:PW@HOST/?pool=true
 > **Note:** If you are using Amazon SES, your URL will look like the following:
 `smtpUrl: smtp://USERNAME:PW@HOST/?requireTLS=true`. If there are `/` or other escape characters in your username or password, you may need to [URL encode](https://www.urlencoder.org/) those characters.
 
-For more insight into how you might be able to customize Astronomer for your team, refer to step 12 at the bottom of this guide. 
+For more insight into how you might be able to customize Astronomer for your team, refer to step 12 at the bottom of this guide.
 
 ## 7. Install Astronomer
 
@@ -203,7 +203,7 @@ $ helm repo add astronomer https://helm.astronomer.io/
 $ helm install astronomer -f config.yaml --version=0.15.0 astronomer/astronomer --namespace astronomer
 ```
 
-This will generate a set of Kubernetes pods that will power the individual services required to run our platform, including the Astronomer UI, our Houston API, etc. 
+This will generate a set of Kubernetes pods that will power the individual services required to run our platform, including the Astronomer UI, our Houston API, etc.
 
 
 ## 8. Verify Pods are Up
@@ -263,7 +263,7 @@ If you are seeing issues here, check out our [guide on debugging your installati
 
 ## 9. Configure DNS
 
-Now that you've successfully installed Astronomer, a new Elastic Load Balancer (ELB) will have spun up in your AWS account. This ELB routes incoming traffic to our NGINX ingress controller.  
+Now that you've successfully installed Astronomer, a new Elastic Load Balancer (ELB) will have spun up in your AWS account. This ELB routes incoming traffic to our NGINX ingress controller.
 
 Run `kubectl get svc -n astronomer` to view your ELB's CNAME, located under the `EXTERNAL-IP` column for the `astronomer-nginx` service.
 
@@ -341,7 +341,7 @@ docker login registry.BASEDOMAIN -u _ p <token>
 
 To help you make the most of Astronomer Enterprise, take note of the following resources:
 
-* [Integrating an Auth System](https://www.astronomer.io/docs/ee-integrating-auth-system/)
+* [Integrating an Auth System](https://www.astronomer.io/docs/enterprise/v0.15/manage-astronomer/integrate-auth-system/)
 * [Configuring Platform Resources](https://www.astronomer.io/docs/ee-configuring-resources/)
 * [Managing Users on Astronomer Enterprise](https://www.astronomer.io/docs/ee-managing-users/)
 

--- a/enterprise/v0.15/03_install/02_gcp/01_install-gcp-standard.md
+++ b/enterprise/v0.15/03_install/02_gcp/01_install-gcp-standard.md
@@ -186,7 +186,7 @@ install.BASEDOMAIN
 
 ```
 
-You can also use a wildcard cert for yourdomain (e.g. `*.astro.BASEDOMAIN.com`). 
+You can also use a wildcard cert for yourdomain (e.g. `*.astro.BASEDOMAIN.com`).
 **Note:** You cannot use a self-signed certificate.
 
 
@@ -292,7 +292,7 @@ nginx:
 
 #################################
 ### SMTP configuration
-#################################  
+#################################
 
 astronomer:
   houston:
@@ -308,7 +308,7 @@ Note - the SMTP URI will take the form:
 smtpUrl: smtps://USERNAME:PW@HOST/?pool=true
 ```
 
-Check out our `Customizing Your Install` section for guidance on setting an [auth system](https://www.astronomer.io/docs/ee-integrating-auth-system/) and [resource requests(https://www.astronomer.io/docs/ee-configuring-resources/) in this `config.yaml`.
+Check out our `Customizing Your Install` section for guidance on setting an [auth system](https://www.astronomer.io/docs/enterprise/v0.15/manage-astronomer/integrate-auth-system/) and [resource requests(https://www.astronomer.io/docs/ee-configuring-resources/) in this `config.yaml`.
 
 ## 8. Install Astronomer
 
@@ -365,7 +365,7 @@ If you are seeing issues here, check out our [guide on debugging your installati
 
 Go to app.BASEDOMAIN to see the Astronomer UI.
 
-## 11. Verify SSL  
+## 11. Verify SSL
 
 To make sure that the certs were accepted, log into the platform and head to `app.BASEDOMAIN/token` and run:
 

--- a/enterprise/v0.15/03_install/03_azure/01_install-azure-standard.md
+++ b/enterprise/v0.15/03_install/03_azure/01_install-azure-standard.md
@@ -256,7 +256,7 @@ nginx:
 
 #################################
 ## SMTP configuration
-#################################  
+#################################
 
 astronomer:
   houston:
@@ -277,7 +277,7 @@ smtpUrl: smtps://USERNAME:PW@HOST/?pool=true
 $ helm install -f config.yaml . --namespace <my-namespace>
 ```
 
-Check out our `Customizing Your Install` section for guidance on setting an [auth system](https://www.astronomer.io/docs/ee-integrating-auth-system/) and [resource requests(https://www.astronomer.io/docs/ee-configuring-resources/) in this `config.yaml`.
+Check out our `Customizing Your Install` section for guidance on setting an [auth system](https://www.astronomer.io/docs/enterprise/v0.15/manage-astronomer/integrate-auth-system/) and [resource requests(https://www.astronomer.io/docs/ee-configuring-resources/) in this `config.yaml`.
 
 ## 10. Verify all pods are up
 

--- a/enterprise/v0.15/04_deploy/02_deploy-code.md
+++ b/enterprise/v0.15/04_deploy/02_deploy-code.md
@@ -15,7 +15,7 @@ In order to push up code to a deployment on Astronomer, you must have:
 
 ### Create a Deployment
 
-To create a deployment on Astronomer, log into the Astronomer UI on either: 
+To create a deployment on Astronomer, log into the Astronomer UI on either:
 - Astronomer Cloud
 - Your own domain on Astronomer Enterprise (`app.BASEDOMAIN`)
 
@@ -31,7 +31,7 @@ To finish creating your Deployment, you'll have to:
 - Pick an Airflow Executor (Celery or Local)
 - Set Initial Resources
 
-![New Deployment Config](https://assets2.astronomer.io/main/docs/deploying-code/v0.15-new_deployment-config.png)
+![New Deployment Config](https://assets2.astronomer.io/main/docs/deploying-code/V0.15-new_deployment-config.png)
 
 ### Deployment Dashboard
 
@@ -98,8 +98,8 @@ astro workspace switch [UUID]
 
 ```
 astro deployment list
- NAME           RELEASE NAME                 ASTRO      DEPLOYMENT ID                            
- demo_cluster     infrared-photon-7780     v0.7.5     c2436025-d501-4944-9c29-19ca61e7f359  
+ NAME           RELEASE NAME                 ASTRO      DEPLOYMENT ID
+ demo_cluster     infrared-photon-7780     v0.7.5     c2436025-d501-4944-9c29-19ca61e7f359
 ```
 
 ### Deploy
@@ -138,7 +138,7 @@ This is largely dependent on personal preference and your particular use case.
 
 ### Workspace Level
 
-At a Workspace level, we recommend having 1 Astronomer Workspace per team of Airflow users. That way, anyone on each team has access to the same set of deployments under that Workspace (RBAC will soon allow you to adjust that access at a deployment level if you'd like). 
+At a Workspace level, we recommend having 1 Astronomer Workspace per team of Airflow users. That way, anyone on each team has access to the same set of deployments under that Workspace (RBAC will soon allow you to adjust that access at a deployment level if you'd like).
 
 ### Deployment Level
 

--- a/enterprise/v0.15/04_deploy/06_ci-cd.md
+++ b/enterprise/v0.15/04_deploy/06_ci-cd.md
@@ -147,7 +147,7 @@ Example:
 docker build -t registry.${BASE_DOMAIN}/${RELEASE_NAME}/airflow:ci-${DRONE_BUILD_NUMBER} .
 ```
 
-If you would like to see a more complete working example please visit our [full example using Drone-CI](https://github.com/astronomer/airflow-example-dags/blob/master/.drone.yml).
+If you would like to see a more complete working example please visit our [full example using Drone-CI](https://github.com/astronomer/airflow-example-dags/blob/main/.drone.yml).
 
 ### Configure Your CI/CD Pipeline
 
@@ -330,7 +330,7 @@ on: [push]
 
 jobs:
   build:
-    runs-on: ubuntu-latest    
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
     - name: Publish to Astronomer.io

--- a/enterprise/v0.15/05_customize-airflow/04_airflow-alerts.md
+++ b/enterprise/v0.15/05_customize-airflow/04_airflow-alerts.md
@@ -27,9 +27,9 @@ You will need fill out some boilerplate survey information, but it's a quick set
 
 A new account will be given 40k emails for the first 30 days and then 100 emails/day for free. As long as your DAGs are working properly, this should be more than enough for most use cases.
 
-After you create your account, you'll reach a view like below. 
+After you create your account, you'll reach a view like below.
 
-#### 2. Click on "Integrate using our Web API or SMTP relay"   
+#### 2. Click on "Integrate using our Web API or SMTP relay"
 ![Sendgrid Getting Started](https://assets2.astronomer.io/main/docs/emails/sendgrid_getting_started.png)
 
 #### 3. Choose the "Web API (recommended)" method
@@ -114,7 +114,7 @@ AIRFLOW__SMTP__SMTP_MAIL_FROM={ENTER_FROM_EMAIL_HERE}
 
 Email alerting set up via `email_on_failure` is handled at the task level. If a handful of your tasks fail for related reasons, you'll receive an individual email for each of those failures.
 
-If you're interested in limiting failure alerts to the DAG run level, you can instead pass `on_failure_callback` ([source](https://github.com/apache/airflow/blob/v1-10-stable/airflow/models.py#L3311)) directly in your DAG file to define a Python function that sends you an email denoting failure.
+If you're interested in limiting failure alerts to the DAG run level, you can instead pass `on_failure_callback` ([source](https://github.com/apache/airflow/blob/v1-10-stable/airflow/models/dag.py#L167)) directly in your DAG file to define a Python function that sends you an email denoting failure.
 
 ```
  :param on_failure_callback: A function to be called when a DagRun of this dag fails.

--- a/enterprise/v0.15/06_manage-astronomer/01_integrate-auth-system.md
+++ b/enterprise/v0.15/06_manage-astronomer/01_integrate-auth-system.md
@@ -4,7 +4,7 @@ navTitle: "Integrate an Auth System"
 description: "Plug your internal authentication server into your Astronomer platform instantiation."
 ---
 
-By default, the Astronomer platform allows you to authenticate using your Google or GitHub account. We provide the option to authenticate using any alternative providers that follow the [Open Id Connect protocol](https://openid.net/connect/) via [Implicit Flow](https://auth0.com/docs/flows/concepts/implicit),  including (but not limited to) [Auth0](https://auth0.com/), [Okta](https://okta.com), and [Microsoft Azure's Active Directory](https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-protocols-oidc). 
+By default, the Astronomer platform allows you to authenticate using your Google or GitHub account. We provide the option to authenticate using any alternative providers that follow the [Open Id Connect protocol](https://openid.net/connect/) via [Implicit Flow](https://auth0.com/docs/flows/concepts/implicit),  including (but not limited to) [Auth0](https://auth0.com/), [Okta](https://www.okta.com), and [Microsoft Azure's Active Directory](https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-protocols-oidc).
 
 ## Configuration
 

--- a/enterprise/v0.15/06_manage-astronomer/03_workspace-permissions.md
+++ b/enterprise/v0.15/06_manage-astronomer/03_workspace-permissions.md
@@ -6,7 +6,7 @@ description: "Manage user roles and permissions within a single Astronomer Works
 
 Astronomer v0.9 and beyond supports role based access control (RBAC), allowing you to configure varying levels of access across all Users within your Workspace.
 
-The Astronomer image comes bundled with an [astronomer-fab-security manager package](https://github.com/astronomer/astronomer-fab-securitymanager/blob/4950500a51755f5b3d1ca288089404bfbd5fba60/README.md_) that connects permissions between
+The Astronomer image comes bundled with an [astronomer-fab-security manager package](https://github.com/astronomer/astronomer-fab-securitymanager/blob/3067c0470dbb1a528d1e251fb45312d01989e6a4/README.md) that connects permissions between
 Houston (the Astronomer API) and Airflow's built-in RBAC.
 
 For details on how those levels of permission are defined and how to leverage them on both Astronomer and Airflow, read the guidelines below.

--- a/enterprise/v0.15/09_resources/01_release-notes.md
+++ b/enterprise/v0.15/09_resources/01_release-notes.md
@@ -32,7 +32,7 @@ For more details on this new feature, reference our ["Environment Variables" doc
 
 Astronomer v0.16 for Astronomer Enterprise users comes with support for Microsoft's [Active Directory Federation services (AD FS)](https://docs.microsoft.com/en-us/windows-server/identity/active-directory-federation-services), as an alternative authentication system.
 
-To learn more, reference ["Auth Systems on Astronomer"](https://www.astronomer.io/docs/ee-integrating-auth-systems/).
+To learn more, reference ["Auth Systems on Astronomer"](https://www.astronomer.io/docs/enterprise/v0.15/manage-astronomer/integrate-auth-system/).
 
 ### Bug Fixes and Improvements
 

--- a/enterprise/v0.16/01_get-started/01_quickstart.md
+++ b/enterprise/v0.16/01_get-started/01_quickstart.md
@@ -153,12 +153,12 @@ Successfully tagged hello-astro_fc483c/airflow:latest
 Creating network "helloastrofc483c_airflow" with driver "bridge"
 Creating volume "helloastrofc483c_postgres_data" with driver "local"
 Creating volume "helloastrofc483c_airflow_logs" with driver "local"
-INFO[0015] [0/3] [postgres]: Starting                   
-INFO[0015] [1/3] [postgres]: Started                    
-INFO[0015] [1/3] [scheduler]: Starting                  
-INFO[0016] [2/3] [scheduler]: Started                   
-INFO[0016] [2/3] [webserver]: Starting                  
-INFO[0016] [3/3] [webserver]: Started                   
+INFO[0015] [0/3] [postgres]: Starting
+INFO[0015] [1/3] [postgres]: Started
+INFO[0015] [1/3] [scheduler]: Starting
+INFO[0016] [2/3] [scheduler]: Started
+INFO[0016] [2/3] [webserver]: Starting
+INFO[0016] [3/3] [webserver]: Started
 Airflow Webserver: http://localhost:8080
 Postgres Database: localhost:5432/postgres
 The default credentials are admin:admin
@@ -181,11 +181,11 @@ Once authenticated, run:
 
 ```
 /hello-astro$ astro deploy
-Authenticated to democluster.astronomer-trials.com 
+Authenticated to democluster.astronomer-trials.com
 
 Select which airflow deployment you want to deploy to:
- #     LABEL     DEPLOYMENT NAME          WORKSPACE     DEPLOYMENT ID                 
- 1     Dev       dynamical-flare-3582     ETLs          ck8g10xxc1zfq0966xlefcpxu     
+ #     LABEL     DEPLOYMENT NAME          WORKSPACE     DEPLOYMENT ID
+ 1     Dev       dynamical-flare-3582     ETLs          ck8g10xxc1zfq0966xlefcpxu
 
 > 1
 Deploying: dynamical-flare-3582
@@ -207,20 +207,20 @@ Successfully built d6e82b576ce5
 Successfully tagged dynamical-flare-3582/airflow:latest
 Pushing image to Astronomer registry
 The push refers to repository [registry.democluster.astronomer-trials.com/dynamical-flare-3582/airflow]
-e5b0f4e97557: Pushed 
-e4f165f2c539: Pushed 
-7ae85d63186e: Pushed 
-3d6737106ee1: Pushed 
-cc0e1283f9aa: Pushed 
-7e57912de03a: Mounted from elementary-rocket-7360/airflow 
-e1aaa247f09d: Mounted from elementary-rocket-7360/airflow 
-c33dcb91918f: Mounted from elementary-rocket-7360/airflow 
-1cb60be4a43a: Mounted from elementary-rocket-7360/airflow 
-3fc755cc03d0: Mounted from elementary-rocket-7360/airflow 
-e09740f41293: Mounted from elementary-rocket-7360/airflow 
-5c858070b896: Mounted from elementary-rocket-7360/airflow 
-95df7c26d7c5: Mounted from elementary-rocket-7360/airflow 
-77cae8ab23bf: Mounted from elementary-rocket-7360/airflow 
+e5b0f4e97557: Pushed
+e4f165f2c539: Pushed
+7ae85d63186e: Pushed
+3d6737106ee1: Pushed
+cc0e1283f9aa: Pushed
+7e57912de03a: Mounted from elementary-rocket-7360/airflow
+e1aaa247f09d: Mounted from elementary-rocket-7360/airflow
+c33dcb91918f: Mounted from elementary-rocket-7360/airflow
+1cb60be4a43a: Mounted from elementary-rocket-7360/airflow
+3fc755cc03d0: Mounted from elementary-rocket-7360/airflow
+e09740f41293: Mounted from elementary-rocket-7360/airflow
+5c858070b896: Mounted from elementary-rocket-7360/airflow
+95df7c26d7c5: Mounted from elementary-rocket-7360/airflow
+77cae8ab23bf: Mounted from elementary-rocket-7360/airflow
 deploy-1: digest: sha256:9e69b7b81efc95c3f024f7656646b523f5b611c1954d52be6dca203c888fc842 size: 3230
 Untagged: registry.democluster.astronomer-trials.com/dynamical-flare-3582/airflow:deploy-1
 Untagged: registry.democluster.astronomer-trials.com/dynamical-flare-3582/airflow@sha256:9e69b7b81efc95c3f024f7656646b523f5b611c1954d52be6dca203c888fc842
@@ -250,6 +250,6 @@ These views show logs and metrics (respectively) acosss all deployments running 
 
 ## 10. Start inviting Users
 
-Now that you've run through all of the functionality on Astronomer enterprise, you're ready to start inviting users! 
+Now that you've run through all of the functionality on Astronomer enterprise, you're ready to start inviting users!
 
-To change the authentication system, naviate to our [Auth Systems](https://www.astronomer.io/docs/ee-integrating-auth-systems/) doc.
+To change the authentication system, naviate to our [Auth Systems](https://www.astronomer.io/docs/enterprise/v0.16/manage-astronomer/integrate-auth-system/) doc.

--- a/enterprise/v0.16/01_get-started/02_faq.md
+++ b/enterprise/v0.16/01_get-started/02_faq.md
@@ -48,16 +48,16 @@ You can find a list of all components used by the platform in the [Astronomer Pl
 No. Astronomer makes use of Kubernetes cluster-level features (including K8s RBAC) by design. These features include creating / deleting namespaces, daemonsets, roles, cluster-roles, service-accounts, resource-quotas, limit-ranges, etc. Additionally, Astronomer dynamically creates new airflow instances in separate namespaces, which protects data engineer users from noisy neighbors.
 
 * Roles
-  * [Houston](https://github.com/astronomer/astronomer/blob/v0.10.3-fix.4/charts/astronomer/templates/houston/houston-bootstrap-role.yaml)
-  * [Prisma](https://github.com/astronomer/astronomer/blob/v0.10.3-fix.4/charts/astronomer/templates/prisma/prisma-bootstrap-role.yaml)
-  * [Kubed](https://github.com/astronomer/astronomer/blob/v0.10.3-fix.4/charts/kubed/templates/kubed-clusterrole.yaml)
-  * [NGINX](https://github.com/astronomer/astronomer/blob/v0.10.3-fix.4/charts/nginx/templates/nginx-role.yaml)
-  * [Commander](https://github.com/astronomer/astronomer/blob/v0.10.3-fix.4/charts/astronomer/templates/commander/commander-role.yaml)
-  * [Fluentd](https://github.com/astronomer/astronomer/blob/v0.10.3-fix.4/charts/fluentd/templates/fluentd-clusterrole.yaml)
-  * [Prometheus](https://github.com/astronomer/astronomer/blob/v0.10.3-fix.4/charts/prometheus/templates/prometheus-role.yaml)
-  * [Grafana](https://github.com/astronomer/astronomer/blob/v0.10.3-fix.4/charts/grafana/templates/grafana-bootstrap-role.yaml)
-  * [Kubestate](https://github.com/astronomer/astronomer/blob/v0.10.3-fix.4/charts/kube-state/templates/kube-state-role.yaml)
-  * [Tiller](https://github.com/astronomer/astronomer/blob/tiller-clusterrole/charts/astronomer/templates/commander/tiller-clusterrole.yaml)
+  * [Houston](https://github.com/astronomer/astronomer/blob/release-0.16/charts/astronomer/templates/houston/houston-bootstrap-role.yaml)
+  * [Prisma](https://github.com/astronomer/astronomer/blob/release-0.16/charts/astronomer/templates/prisma/prisma-bootstrap-role.yaml)
+  * [Kubed](https://github.com/astronomer/astronomer/blob/release-0.16/charts/kubed/templates/kubed-clusterrole.yaml)
+  * [NGINX](https://github.com/astronomer/astronomer/blob/release-0.16/charts/nginx/templates/nginx-role.yaml)
+  * [Commander](https://github.com/astronomer/astronomer/blob/release-0.16/charts/astronomer/templates/commander/commander-role.yaml)
+  * [Fluentd](https://github.com/astronomer/astronomer/blob/release-0.16/charts/fluentd/templates/fluentd-clusterrole.yaml)
+  * [Prometheus](https://github.com/astronomer/astronomer/blob/release-0.16/charts/prometheus/templates/prometheus-role.yaml)
+  * [Grafana](https://github.com/astronomer/astronomer/blob/release-0.16/charts/grafana/templates/grafana-bootstrap-role.yaml)
+  * [Kubestate](https://github.com/astronomer/astronomer/blob/release-0.16/charts/kube-state/templates/kube-state-role.yaml)
+  * [Tiller](https://github.com/astronomer/astronomer/blob/release-0.16/charts/astronomer/templates/commander/commander-role.yaml)
 
 ### How can we restrict the application from getting full access?
 
@@ -85,13 +85,13 @@ You may have special requirements of your infrastructure such that you want to s
 
 ### How can we integrate with LDAP?
 
-See https://www.astronomer.io/docs/ee-integrating-auth-systems/
+See https://www.astronomer.io/docs/enterprise/v0.16/manage-astronomer/integrate-auth-system/
 
 ### How can we get multi-factor auth?
 
-Astronomer has a flexible [auth front end](https://www.astronomer.io/docs/ee-integrating-auth-systems/), with pre-built integrations for Google Auth, Okta, Auth0, and others.
+Astronomer has a flexible [auth front end](https://www.astronomer.io/docs/enterprise/v0.16/manage-astronomer/integrate-auth-system/), with pre-built integrations for Google Auth, Okta, Auth0, and others.
 
-If you choose to use Google Auth, we have [documentation available](https://www.astronomer.io/docs/ee-installation-google-oauth/). 
+If you choose to use Google Auth, we have [documentation available](https://www.astronomer.io/docs/ee-installation-google-oauth/).
 
 ### How can implement RBAC with this solution?
 

--- a/enterprise/v0.16/03_install/01_aws/01_install-aws-standard.md
+++ b/enterprise/v0.16/03_install/01_aws/01_install-aws-standard.md
@@ -25,7 +25,7 @@ All Astronomer services will be tied to a base domain of your choice, under whic
 
 Once created, your Astronomer base domain will be linked to a variety of sub-services that your users will access via the internet to manage, monitor and run Airflow on the platform.
 
-For the base domain `astro.mydomain.com`, for example, here are some corresponding URLs that your users would be able to reach: 
+For the base domain `astro.mydomain.com`, for example, here are some corresponding URLs that your users would be able to reach:
 
 * Astronomer UI: `app.astro.mydomain.com`
 * Airflow Deployments: `deployments.astro.mydomain.com/uniquely-generated-airflow-name/airflow`
@@ -38,7 +38,7 @@ For the full list of subdomains you need a certificate for, read below.
 
 To proceed with the installation, you'll need to spin up an [EKS Control Plane](https://aws.amazon.com/eks/) as well as worker nodes in your Kubernetes cluster by following [this AWS guide](https://docs.aws.amazon.com/eks/latest/userguide/getting-started.html).
 
-EKS is built off of Amazon's pre-existing EC2 service, so you can manage your Kubernetes nodes the same way you would manage your EC2 nodes. 
+EKS is built off of Amazon's pre-existing EC2 service, so you can manage your Kubernetes nodes the same way you would manage your EC2 nodes.
 
 As you follow the guide linked above, keep in mind:
 * Astronomer supports Kubernetes versions 1.14 and 1.15 (support for 1.16 coming soon).
@@ -169,7 +169,7 @@ nginx:
 
 #################################
 ### SMTP configuration
-#################################  
+#################################
 
 astronomer:
   houston:
@@ -177,7 +177,7 @@ astronomer:
       email:
         enabled: true
         smtpUrl: YOUR_URI_HERE
-``` 
+```
 
 SMTP is required and will allow users to send and accept email invites to Astronomer. The SMTP URI will take the following form:
 
@@ -188,7 +188,7 @@ smtpUrl: smtps://USERNAME:PW@HOST/?pool=true
 > **Note:** If you are using Amazon SES, your URL will look like the following:
 `smtpUrl: smtp://USERNAME:PW@HOST/?requireTLS=true`. If there are `/` or other escape characters in your username or password, you may need to [URL encode](https://www.urlencoder.org/) those characters.
 
-For more insight into how you might be able to customize Astronomer for your team, refer to step 12 at the bottom of this guide. 
+For more insight into how you might be able to customize Astronomer for your team, refer to step 12 at the bottom of this guide.
 
 ## 7. Install Astronomer
 
@@ -203,7 +203,7 @@ $ helm repo add astronomer https://helm.astronomer.io/
 $ helm install astronomer -f config.yaml --version=0.15.0 astronomer/astronomer --namespace astronomer
 ```
 
-This will generate a set of Kubernetes pods that will power the individual services required to run our platform, including the Astronomer UI, our Houston API, etc. 
+This will generate a set of Kubernetes pods that will power the individual services required to run our platform, including the Astronomer UI, our Houston API, etc.
 
 
 ## 8. Verify Pods are Up
@@ -263,7 +263,7 @@ If you are seeing issues here, check out our [guide on debugging your installati
 
 ## 9. Configure DNS
 
-Now that you've successfully installed Astronomer, a new Elastic Load Balancer (ELB) will have spun up in your AWS account. This ELB routes incoming traffic to our NGINX ingress controller.  
+Now that you've successfully installed Astronomer, a new Elastic Load Balancer (ELB) will have spun up in your AWS account. This ELB routes incoming traffic to our NGINX ingress controller.
 
 Run `kubectl get svc -n astronomer` to view your ELB's CNAME, located under the `EXTERNAL-IP` column for the `astronomer-nginx` service.
 
@@ -341,7 +341,7 @@ docker login registry.BASEDOMAIN -u _ p <token>
 
 To help you make the most of Astronomer Enterprise, take note of the following resources:
 
-* [Integrating an Auth System](https://www.astronomer.io/docs/ee-integrating-auth-system/)
+* [Integrating an Auth System](https://www.astronomer.io/docs/enterprise/v0.16/manage-astronomer/integrate-auth-system/)
 * [Configuring Platform Resources](https://www.astronomer.io/docs/ee-configuring-resources/)
 * [Managing Users on Astronomer Enterprise](https://www.astronomer.io/docs/ee-managing-users/)
 

--- a/enterprise/v0.16/03_install/02_gcp/01_install-gcp-standard.md
+++ b/enterprise/v0.16/03_install/02_gcp/01_install-gcp-standard.md
@@ -186,7 +186,7 @@ install.BASEDOMAIN
 
 ```
 
-You can also use a wildcard cert for yourdomain (e.g. `*.astro.BASEDOMAIN.com`). 
+You can also use a wildcard cert for yourdomain (e.g. `*.astro.BASEDOMAIN.com`).
 **Note:** You cannot use a self-signed certificate.
 
 
@@ -292,7 +292,7 @@ nginx:
 
 #################################
 ### SMTP configuration
-#################################  
+#################################
 
 astronomer:
   houston:
@@ -308,7 +308,7 @@ Note - the SMTP URI will take the form:
 smtpUrl: smtps://USERNAME:PW@HOST/?pool=true
 ```
 
-Check out our `Customizing Your Install` section for guidance on setting an [auth system](https://www.astronomer.io/docs/ee-integrating-auth-system/) and [resource requests(https://www.astronomer.io/docs/ee-configuring-resources/) in this `config.yaml`.
+Check out our `Customizing Your Install` section for guidance on setting an [auth system](https://www.astronomer.io/docs/enterprise/v0.16/manage-astronomer/integrate-auth-system/) and [resource requests(https://www.astronomer.io/docs/ee-configuring-resources/) in this `config.yaml`.
 
 ## 8. Install Astronomer
 
@@ -365,7 +365,7 @@ If you are seeing issues here, check out our [guide on debugging your installati
 
 Go to app.BASEDOMAIN to see the Astronomer UI.
 
-## 11. Verify SSL  
+## 11. Verify SSL
 
 To make sure that the certs were accepted, log into the platform and head to `app.BASEDOMAIN/token` and run:
 

--- a/enterprise/v0.16/03_install/03_azure/01_install-azure-standard.md
+++ b/enterprise/v0.16/03_install/03_azure/01_install-azure-standard.md
@@ -256,7 +256,7 @@ nginx:
 
 #################################
 ## SMTP configuration
-#################################  
+#################################
 
 astronomer:
   houston:
@@ -277,7 +277,7 @@ smtpUrl: smtps://USERNAME:PW@HOST/?pool=true
 $ helm install -f config.yaml . --namespace <my-namespace>
 ```
 
-Check out our `Customizing Your Install` section for guidance on setting an [auth system](https://www.astronomer.io/docs/ee-integrating-auth-system/) and [resource requests(https://www.astronomer.io/docs/ee-configuring-resources/) in this `config.yaml`.
+Check out our `Customizing Your Install` section for guidance on setting an [auth system](https://www.astronomer.io/docs/enterprise/v0.16/manage-astronomer/integrate-auth-system/) and [resource requests(https://www.astronomer.io/docs/ee-configuring-resources/) in this `config.yaml`.
 
 ## 10. Verify all pods are up
 

--- a/enterprise/v0.16/04_deploy/02_deploy-code.md
+++ b/enterprise/v0.16/04_deploy/02_deploy-code.md
@@ -15,7 +15,7 @@ In order to push up code to a deployment on Astronomer, you must have:
 
 ### Create a Deployment
 
-To create a deployment on Astronomer, log into the Astronomer UI on either: 
+To create a deployment on Astronomer, log into the Astronomer UI on either:
 - Astronomer Cloud
 - Your own domain on Astronomer Enterprise (`app.BASEDOMAIN`)
 
@@ -31,7 +31,7 @@ To finish creating your Deployment, you'll have to:
 - Pick an Airflow Executor (Celery or Local)
 - Set Initial Resources
 
-![New Deployment Config](https://assets2.astronomer.io/main/docs/deploying-code/v0.15-new_deployment-config.png)
+![New Deployment Config](https://assets2.astronomer.io/main/docs/deploying-code/V0.15-new_deployment-config.png)
 
 ### Deployment Dashboard
 
@@ -98,8 +98,8 @@ astro workspace switch [UUID]
 
 ```
 astro deployment list
- NAME           RELEASE NAME                 ASTRO      DEPLOYMENT ID                            
- demo_cluster     infrared-photon-7780     v0.7.5     c2436025-d501-4944-9c29-19ca61e7f359  
+ NAME           RELEASE NAME                 ASTRO      DEPLOYMENT ID
+ demo_cluster     infrared-photon-7780     v0.7.5     c2436025-d501-4944-9c29-19ca61e7f359
 ```
 
 ### Deploy
@@ -138,7 +138,7 @@ This is largely dependent on personal preference and your particular use case.
 
 ### Workspace Level
 
-At a Workspace level, we recommend having 1 Astronomer Workspace per team of Airflow users. That way, anyone on each team has access to the same set of deployments under that Workspace (RBAC will soon allow you to adjust that access at a deployment level if you'd like). 
+At a Workspace level, we recommend having 1 Astronomer Workspace per team of Airflow users. That way, anyone on each team has access to the same set of deployments under that Workspace (RBAC will soon allow you to adjust that access at a deployment level if you'd like).
 
 ### Deployment Level
 

--- a/enterprise/v0.16/04_deploy/06_ci-cd.md
+++ b/enterprise/v0.16/04_deploy/06_ci-cd.md
@@ -147,7 +147,7 @@ Example:
 docker build -t registry.${BASE_DOMAIN}/${RELEASE_NAME}/airflow:ci-${DRONE_BUILD_NUMBER} .
 ```
 
-If you would like to see a more complete working example please visit our [full example using Drone-CI](https://github.com/astronomer/airflow-example-dags/blob/master/.drone.yml).
+If you would like to see a more complete working example please visit our [full example using Drone-CI](https://github.com/astronomer/airflow-example-dags/blob/main/.drone.yml).
 
 ### Configure Your CI/CD Pipeline
 
@@ -330,7 +330,7 @@ on: [push]
 
 jobs:
   build:
-    runs-on: ubuntu-latest    
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
     - name: Publish to Astronomer.io

--- a/enterprise/v0.16/05_customize-airflow/04_airflow-alerts.md
+++ b/enterprise/v0.16/05_customize-airflow/04_airflow-alerts.md
@@ -27,9 +27,9 @@ You will need fill out some boilerplate survey information, but it's a quick set
 
 A new account will be given 40k emails for the first 30 days and then 100 emails/day for free. As long as your DAGs are working properly, this should be more than enough for most use cases.
 
-After you create your account, you'll reach a view like below. 
+After you create your account, you'll reach a view like below.
 
-#### 2. Click on "Integrate using our Web API or SMTP relay"   
+#### 2. Click on "Integrate using our Web API or SMTP relay"
 ![Sendgrid Getting Started](https://assets2.astronomer.io/main/docs/emails/sendgrid_getting_started.png)
 
 #### 3. Choose the "Web API (recommended)" method
@@ -114,7 +114,7 @@ AIRFLOW__SMTP__SMTP_MAIL_FROM={ENTER_FROM_EMAIL_HERE}
 
 Email alerting set up via `email_on_failure` is handled at the task level. If a handful of your tasks fail for related reasons, you'll receive an individual email for each of those failures.
 
-If you're interested in limiting failure alerts to the DAG run level, you can instead pass `on_failure_callback` ([source](https://github.com/apache/airflow/blob/v1-10-stable/airflow/models.py#L3311)) directly in your DAG file to define a Python function that sends you an email denoting failure.
+If you're interested in limiting failure alerts to the DAG run level, you can instead pass `on_failure_callback` ([source](https://github.com/apache/airflow/blob/v1-10-stable/airflow/models/dag.py#L167)) directly in your DAG file to define a Python function that sends you an email denoting failure.
 
 ```
  :param on_failure_callback: A function to be called when a DagRun of this dag fails.

--- a/enterprise/v0.16/06_manage-astronomer/01_integrate-auth-system.md
+++ b/enterprise/v0.16/06_manage-astronomer/01_integrate-auth-system.md
@@ -15,7 +15,7 @@ Astronomer Enterprise by default allows users to create an account with and auth
 Authentication methods are entirely customizable. In addition to the 3 defaults above, we provide the option to integrate any provider that follows the [Open Id Connect (OIDC)](https://openid.net/connect/) protocol via [Implicit Flow](https://auth0.com/docs/flows/concepts/implicit). This includes (but is not limited to):
 
 - [Microsoft Azure Active Directory (AD)](https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-protocols-oidc)
-- [Okta](https://okta.com)
+- [Okta](https://www.okta.com)
 - [Auth0](https://auth0.com/)
 
 The doc below will walk through how to both enable local authentication and configure any OIDC provider, including step-by-step instructions for the 3 providers listed above.
@@ -69,7 +69,7 @@ Replace the values above with those of the provider of your choice. If you want 
 
 ### Register the Application via `App Registrations` on Azure
 
-To start, register the application. As you do so, make sure to include the Redirect URI as the following: https://houston.BASEDOMAIN/v1/oauth/redirect. 
+To start, register the application. As you do so, make sure to include the Redirect URI as the following: https://houston.BASEDOMAIN/v1/oauth/redirect.
 
 Replace `BASEDOMAIN` with your own. For example, if your basedomain were `astronomer-development.com`, your registration would look like the following:
 

--- a/enterprise/v0.16/06_manage-astronomer/03_workspace-permissions.md
+++ b/enterprise/v0.16/06_manage-astronomer/03_workspace-permissions.md
@@ -6,7 +6,7 @@ description: "Manage user roles and permissions within a single Astronomer Works
 
 Astronomer v0.9 and beyond supports role based access control (RBAC), allowing you to configure varying levels of access across all Users within your Workspace.
 
-The Astronomer image comes bundled with an [astronomer-fab-security manager package](https://github.com/astronomer/astronomer-fab-securitymanager/blob/4950500a51755f5b3d1ca288089404bfbd5fba60/README.md_) that connects permissions between
+The Astronomer image comes bundled with an [astronomer-fab-security manager package](https://github.com/astronomer/astronomer-fab-securitymanager/blob/3067c0470dbb1a528d1e251fb45312d01989e6a4/README.md) that connects permissions between
 Houston (the Astronomer API) and Airflow's built-in RBAC.
 
 For details on how those levels of permission are defined and how to leverage them on both Astronomer and Airflow, read the guidelines below.

--- a/enterprise/v0.16/09_resources/01_release-notes.md
+++ b/enterprise/v0.16/09_resources/01_release-notes.md
@@ -32,7 +32,7 @@ For more details on this new feature, reference our ["Environment Variables" doc
 
 Astronomer v0.16 for Astronomer Enterprise users comes with support for Microsoft's [Active Directory Federation services (AD FS)](https://docs.microsoft.com/en-us/windows-server/identity/active-directory-federation-services), as an alternative authentication system.
 
-To learn more, reference ["Auth Systems on Astronomer"](https://www.astronomer.io/docs/ee-integrating-auth-systems/).
+To learn more, reference ["Auth Systems on Astronomer"](https://www.astronomer.io/docs/enterprise/v0.16/manage-astronomer/integrate-auth-system/).
 
 ### Bug Fixes and Improvements
 


### PR DESCRIPTION
I wrote a small shell pipeline to check all the hyperlinks in the docs for problems, then fixed all the non-200,300 problems.

```sh
# ggrep is GNU grep on macOS. normal grep works in Linux.
ggrep -R -h -oP '\(\Khttp[^)]*(?=\))' . |
sort -u |
while read -r X ; do
  echo "$(curl --max-filesize 1 -s -w "%{http_code}\n" -o /dev/null $X) $X"
done |
grep -v '^[23]00' > ~/problem-links.txt
```

Also I used [a pre-commit hook to trim trailing whitespace](https://pre-commit.com/hooks.html) in the files I touched, but did not commit the pre-commit config. We can discuss that in another PR if it's something we want to do.