### PR TITLE
Markdown formatting (inline code usage)

### DIFF
--- a/cloud/stable/02_develop/02_customize-image.md
+++ b/cloud/stable/02_develop/02_customize-image.md
@@ -21,7 +21,7 @@ More specifically, this doc includes instructions for how to:
 
 ## Add Python and OS-level Packages
 
-To build Python and OS-level packages into your Airflow Deployment, add them to your `requirements.txt` and `packages.txt` files on Astronomer. Both files were automatically generated when you intialized an Airflow project locally via `$ astro dev init`. Steps below.
+To build Python and OS-level packages into your Airflow Deployment, add them to your `requirements.txt` and `packages.txt` files on Astronomer. Both files were automatically generated when you initialized an Airflow project locally via `$ astro dev init`. Steps below.
 
 ### Add your Python or OS-Level Package
 

--- a/cloud/stable/03_deploy/01_manage-workspaces.md
+++ b/cloud/stable/03_deploy/01_manage-workspaces.md
@@ -8,15 +8,13 @@ We've designed the Astronomer UI as a place for you to easily manage users, Airf
 
 ## Dashboard
 
-Once logged in, you'll land on a dashboard that gives you an overview of your Workspaces. We'll call this the **Account Dashboard**:
+Once logged in, you'll land on a view that will direct you to create a new **Workspace**. From this view, you can:
+
+1. Create a new Workspace
+2. View the Workspaces you have access to in the left-hand navigation
+3. Access "Documentation," "Account Settings" and more in the Account drop-down menu
 
 ![Account Dashboard](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.12-empty-dashboard.png)
-
-From this dashboard, you can:
-
-1. Spin up new Workspaces
-2. View the Workspaces you currently have access to
-3. Update your name from the "Account Settings" menu
 
 ## Workspaces
 

--- a/cloud/stable/03_deploy/01_manage-workspaces.md
+++ b/cloud/stable/03_deploy/01_manage-workspaces.md
@@ -8,7 +8,7 @@ We've designed the Astronomer UI as a place for you to easily manage users, Airf
 
 ## Dashboard
 
-Once logged in, you'll land on a dashboard that gives you an overview of your Workspaces. We'll call this the `Account Dashboard`:
+Once logged in, you'll land on a dashboard that gives you an overview of your Workspaces. We'll call this the **Account Dashboard**:
 
 ![Account Dashboard](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.12-empty-dashboard.png)
 
@@ -22,13 +22,13 @@ From this dashboard, you can:
 
 **The Astronomer Workspace:** A personal or shared space that is home to a collection of Airflow deployments. User access to deployments is managed at the workspace level on Astronomer.
 
-A `Workspace` is an Astronomer-specific term. You can think of your workspaces the same way you'd think of teams - they're just collections of Airflow deployments that specific user groups have access to. When you create an account on Astronomer, a default personal workspace is automatically created. Airflow deployments are hierarchically lower - from a workspace, you can create one or more Airflow deployments, and grant or restrict user access to those deployments accordingly.
+A **Workspace** is an Astronomer-specific term. You can think of your workspaces the same way you'd think of teams - they're just collections of Airflow deployments that specific user groups have access to. When you create an account on Astronomer, a default personal workspace is automatically created. Airflow deployments are hierarchically lower - from a workspace, you can create one or more Airflow deployments, and grant or restrict user access to those deployments accordingly.
 
 If you were a solo agent, you could have multiple Airflow deployments within that single workspace and have no need for additional workspaces. Teams, however, often share one or more workspaces labeled as such, and have multiple Airflow deployments from there.
 
 Deployments cannot be used or shared across workspaces. While you’re free to push local DAGs and code anywhere you wish at any time, there is currently no way to move an existing Airflow instance from one workspace to another once deployed.
 
-Once you click into a workspace, you'll land on another dashboard that we'll call the `Workspace Dashboard`:
+Once you click into a workspace, you'll land on another dashboard that we'll call the **Workspace Dashboard**:
 
 ![Workspace Dashboard](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.12-deployments.png)
 
@@ -49,11 +49,11 @@ Since all of our app activity is routed through a GraphQL API, you're free to cr
 
 An [Apache Airflow](https://airflow.apache.org/) Deployment is made up of a Scheduler, a Webserver and, if you're running the Celery or Kubernetes Executors, one or more Workers. An Airflow Deployment within a Workspce has the capacity to host a collection of DAGs.
 
-In the context of Astronomer, the term `Airflow Deployment` is used to describe an instance of Airflow that you've spun up either via our [UI](https://astronomer.io/docs/overview) or [CLI](https://astronomer.io/docs/cli-quickstart) as part of a Workspace. Under the hood, each Airflow Deployment gets its own Kubernetes namespace and has a reserved set of dedicated resources and an underlying Postgres Metadata Database.
+In the context of Astronomer, the term **Airflow Deployment** is used to describe an instance of Airflow that you've spun up either via our [UI](https://astronomer.io/docs/overview) or [CLI](https://astronomer.io/docs/cli-quickstart) as part of a Workspace. Under the hood, each Airflow Deployment gets its own Kubernetes namespace and has a reserved set of dedicated resources and an underlying Postgres Metadata Database.
 
 You're able to adjust the resources given to your Airflow deployment directly from the UI. This functionality allows you to choose executor (local or celery) and easily provision additional resources as you scale up.
 
-From the Workspace dashboard, navigate back to the `Deployments` tab.
+From the Workspace dashboard, navigate back to the "Deployments" tab.
 
 If you click into one of your Airflow deployments, you'll land on a page that looks like this:
 
@@ -62,7 +62,7 @@ If you click into one of your Airflow deployments, you'll land on a page that lo
 From here, you'll be able to access:
 
 1. Airflow UI (DAG Dashboard)
-2. Flower dashboard (if you are running the Celery executor)
+2. Flower Dashboard (if you are running the Celery executor)
 
 The former will link you directly to your DAG Dashboard on Airflow itself. Your Flower Dashboard is your go-to spot to monitor your Celery Workers.
 
@@ -72,10 +72,10 @@ For a breakdown the Airflow UI itself, check out [this guide](https://www.astron
 
 ## User Management
 
-If you navigate over to the `Users` tab of your Workspace Dashboard, you'll be able to see who has access to the Workspace.
+If you navigate over to the "Users" tab of your Workspace Dashboard, you'll be able to see who has access to the Workspace.
 
 If you'd like to share access to other members of your organization, invite them to a Workspace you're a part of. Once members, they'll have access to _all_ Airflow deployments under that workspace with varying permissions.
 
 ### Workspace Permissions
 
-Users in a Workspace can be given the role of a `Viewer`, `Editor`, or `Admin`. An exact breakdown of these roles can be found in the [User Roles and Permissions](https://www.astronomer.io/docs/rbac/) section. Astronomer Enterprise admins can [configure the exact permissions](https://www.astronomer.io/docs/ee-configuring-permissions/) for each Astronomer role.
+Users in a Workspace can be given the role of a **Viewer**, **Editor**, or **Admin***. An exact breakdown of these roles can be found in the [User Roles and Permissions](https://www.astronomer.io/docs/rbac/) section. Astronomer Enterprise admins can [configure the exact permissions](https://www.astronomer.io/docs/ee-configuring-permissions/) for each Astronomer role.

--- a/cloud/stable/03_deploy/01_manage-workspaces.md
+++ b/cloud/stable/03_deploy/01_manage-workspaces.md
@@ -49,7 +49,7 @@ Since all of our app activity is routed through a GraphQL API, you're free to cr
 
 An [Apache Airflow](https://airflow.apache.org/) Deployment is made up of a Scheduler, a Webserver and, if you're running the Celery or Kubernetes Executors, one or more Workers. An Airflow Deployment within a Workspce has the capacity to host a collection of DAGs.
 
-In the context of Astronomer, the term **Airflow Deployment** is used to describe an instance of Airflow that you've spun up either via our [UI](https://astronomer.io/docs/overview) or [CLI](https://astronomer.io/docs/cli-quickstart) as part of a Workspace. Under the hood, each Airflow Deployment gets its own Kubernetes namespace and has a reserved set of dedicated resources and an underlying Postgres Metadata Database.
+In the context of Astronomer, the term **Airflow Deployment** is used to describe an instance of Airflow that you've spun up either via the Astronomer UI or [CLI](https://astronomer.io/docs/cli-quickstart) as part of a Workspace. Under the hood, each Airflow Deployment gets its own Kubernetes namespace and has a reserved set of dedicated resources and an underlying Postgres Metadata Database.
 
 You're able to adjust the resources given to your Airflow deployment directly from the UI. This functionality allows you to choose executor (local or celery) and easily provision additional resources as you scale up.
 

--- a/cloud/stable/03_deploy/01_manage-workspaces.md
+++ b/cloud/stable/03_deploy/01_manage-workspaces.md
@@ -16,7 +16,7 @@ From this dashboard, you can:
 
 1. Spin up new Workspaces
 2. View the Workspaces you currently have access to
-3. Adjust your account name under the `Personal Settings` tab
+3. Update your name from the "Account Settings" menu
 
 ## Workspaces
 

--- a/cloud/stable/03_deploy/02_deploy-cli.md
+++ b/cloud/stable/03_deploy/02_deploy-cli.md
@@ -17,7 +17,7 @@ In order to push up code to a deployment on Astronomer, you must have:
 
 To create a deployment on Astronomer, log into [Astronomer Cloud](https://app.gcp0001.us-east4.astronomer.io/).
 
-From your Workspace on Astronomer, click `New Deployment`.
+From your Workspace on Astronomer, click "New Deployment".
 
 ![Workspace Dashboard](https://assets2.astronomer.io/main/docs/astronomer-ui/workspace_dashboard.png)
 

--- a/cloud/stable/03_deploy/03_configure-deployment.md
+++ b/cloud/stable/03_deploy/03_configure-deployment.md
@@ -9,12 +9,12 @@ Once you've created your deployment, you can configure it for the use case at ha
 ## Allocating Resources
 
 
-The `Settings` tab allows you to adjust your resource components - empowering you to freely scale your deployment up or down as you wish. To this end, you can:
+The "Settings" tab allows you to adjust your resource components - empowering you to freely scale your deployment up or down as you wish. To this end, you can:
 
 1. Choose your Executor (Local, Celery, or Kubernetes)
 2. Adjust resources to your Scheduler and Webserver
-3. Adjust worker count (*Celery only*)
-4. Adjust your `Worker Termination Grace Period` (*Celery only*)
+3. Adjust Worker Count (*Celery only*)
+4. Adjust your Worker Termination Grace Period (*Celery only*)
 5. Add Extra Capacity (*Kubernetes or KubernetesPodOperator only*)
 
 ![Astro UI Executor Config](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.15-Astro-UI-Executor.png)
@@ -43,7 +43,7 @@ If your Airflow UI is slow or crashes when you try to load a large DAG, you'll w
 
 ### Extra Capacity
 
-The `Extra Capacity` setting is tied to the [KubernetesPodOperator](https://www.astronomer.io/docs/kubepodoperator/) and the KubernetesExecutor, as it maps to extra pods created in the cluster. Namely, the slider effects:
+The **Extra Capacity** setting is tied to the [KubernetesPodOperator](https://www.astronomer.io/docs/kubepodoperator/) and the KubernetesExecutor, as it maps to extra pods created in the cluster. Namely, the slider effects:
 
 1. CPU and memory quotas
 2. Database connection limits.

--- a/cloud/stable/03_deploy/03_configure-deployment.md
+++ b/cloud/stable/03_deploy/03_configure-deployment.md
@@ -43,7 +43,7 @@ If your Airflow UI is slow or crashes when you try to load a large DAG, you'll w
 
 ### Extra Capacity
 
-The **Extra Capacity** setting is tied to the [KubernetesPodOperator](https://www.astronomer.io/docs/kubepodoperator/) and the KubernetesExecutor, as it maps to extra pods created in the cluster. Namely, the slider effects:
+The **Extra Capacity** setting is tied to the [KubernetesPodOperator](https://www.astronomer.io/docs/kubepodoperator/) and the KubernetesExecutor, as it maps to extra pods created in the cluster. Namely, the slider affects:
 
 1. CPU and memory quotas
 2. Database connection limits.

--- a/cloud/stable/03_deploy/05_environment-variables.md
+++ b/cloud/stable/03_deploy/05_environment-variables.md
@@ -129,7 +129,7 @@ The last way to add Environment Variables on Astronomer is to add them via the A
 To set them,
 
 1. Navigate to the Astronomer UI
-2. Go to `Deployment` > `Variables`
+2. Go to **Deployment** > **Variables**
 3. Add your Environment Variables
 
 ![Astro UI Env Vars Config](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.16-Astro-UI-EnvVars.png)
@@ -140,32 +140,32 @@ To set them,
 
 On Astronomer, users have the ability to mark any Environment Variable as "secret" via the UI. For those who have Environment Variables containing potentially sensitive information (e.g. SMTP password, S3 bucket, etc.), we'd recommend leveraging this feature.
 
-To do so from the `Variables` tab,
+To do so from the "Variables" tab,
 
 1. Enter a Key
 2. Enter a Value
-3. Check off the `Secret?` box
-4. Click `Add`
-5. Press `Deploy Changes`
+3. Check the "Secret?" box
+4. Click "Add"
+5. Press "Deploy Changes"
 
-Once changes are deployed, Environment Variables marked as 'secret' will NOT be available in plain-text to any user in the Workspace.
+Once changes are deployed, Environment Variables marked as "secret" will NOT be available in plain-text to any user in the Workspace.
 
 A few additional notes:
 
-- Workspace Editors and Admins are free to set an existing non-secret Env Var to 'secret' any time
-- To convert a 'secret' Env Var to a 'non-secret' Env Var, you'll be prompted to enter a new value
-- If you export Environment Variables via JSON, 'secret' values will NOT render in plain-text
+- Workspace Editors and Admins are free to set an existing non-secret Env Var to "secret" any time
+- To convert a "secret" Env Var to a "non-secret" Env Var, you'll be prompted to enter a new value
+- If you export Environment Variables via JSON, "secret" values will NOT render in plain-text
 - Users cannot add a new variable that has the same key as an existing variable
 
 Read below for more detail on how Environment Variables are encrypted on Astronomer.
 
-> **Note:** As noted above, Workspace roles and permissions apply to actions in the `Variables` tab. For a full breakdown of permissions for each role, reference Astronomer's ["Roles and Permissions" doc](https://www.astronomer.io/docs/rbac/).
+> **Note:** As noted above, Workspace roles and permissions apply to actions in the "Variables" tab. For a full breakdown of permissions for each role, reference Astronomer's ["Roles and Permissions" doc](https://www.astronomer.io/docs/rbac/).
 
 ### Precedence amongst 3 Methods
 
 Given the ability to set Environment Variables across 3 different methods potentially simultaneously, it's worth noting the precedence each take.
 
-On Astronomer, Environment Variables will be applied and overriden in the following order:
+On Astronomer, Environment Variables will be applied and overridden in the following order:
 
 1. Astronomer UI
 2. .env (_Local Only_)

--- a/cloud/stable/03_deploy/05_environment-variables.md
+++ b/cloud/stable/03_deploy/05_environment-variables.md
@@ -129,7 +129,7 @@ The last way to add Environment Variables on Astronomer is to add them via the A
 To set them,
 
 1. Navigate to the Astronomer UI
-2. Go to **Deployment** > **Variables**
+2. Go to "Deployment" > "Variables"
 3. Add your Environment Variables
 
 ![Astro UI Env Vars Config](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.16-Astro-UI-EnvVars.png)

--- a/cloud/stable/03_deploy/06_ci-cd.md
+++ b/cloud/stable/03_deploy/06_ci-cd.md
@@ -97,7 +97,7 @@ Upon creating a Service Account, make sure to:
 * Give it a Category (optional)
 * Grant it a User Role
 
-> **Note:** In order for a Service Account to have permission to push code to your Airflow Deployment, it must have either the `Editor` or `Admin` role. For more information on Workspace roles, refer to our ["Roles and Permissions"](https://www.astronomer.io/docs/rbac/) doc.
+> **Note:** In order for a Service Account to have permission to push code to your Airflow Deployment, it must have either the "Editor" or "Admin" role. For more information on Workspace roles, refer to our ["Roles and Permissions"](https://www.astronomer.io/docs/rbac/) doc.
 
 ![Name Service Account](https://assets2.astronomer.io/main/docs/ci-cd/ci-cd-name-service-account.png)
 
@@ -140,7 +140,7 @@ registry.gcp0001.us-east4.astronomer.io
 
 #### Tag Name
 
-*Tag Name*: Each deploy to Astronomer Cloud generated a Docker image with a corresponding tag. If you deploy via the CLI, the tag will by default read `deploy-n`, with `n` representing the numnber of deploys made to that Airflow Deployment. If you're using CI/CD, you get to customize this tag. We typically recommend specifying the source and the build number in the name.
+*Tag Name*: Each deploy to Astronomer Cloud generated a Docker image with a corresponding tag. If you deploy via the CLI, the tag will by default read `deploy-n`, with `n` representing the number of deploys made to that Airflow Deployment. If you're using CI/CD, you get to customize this tag. We typically recommend specifying the source and the build number in the name.
 
 In the example below, we use the prefix `ci-` and the ENV `${DRONE_BUILD_NUMBER}`. This guarantees that we always know which CI/CD build triggered the build and push.
 

--- a/enterprise/next/02_develop/02_customize-image.md
+++ b/enterprise/next/02_develop/02_customize-image.md
@@ -21,7 +21,7 @@ More specifically, this doc includes instructions for how to:
 
 ## Add Python and OS-level Packages
 
-To build Python and OS-level packages into your Airflow Deployment, add them to your `requirements.txt` and `packages.txt` files on Astronomer. Both files were automatically generated when you intialized an Airflow project locally via `$ astro dev init`. Steps below.
+To build Python and OS-level packages into your Airflow Deployment, add them to your `requirements.txt` and `packages.txt` files on Astronomer. Both files were automatically generated when you initialized an Airflow project locally via `$ astro dev init`. Steps below.
 
 ### Add your Python or OS-Level Package
 

--- a/enterprise/next/04_deploy/01_manage-workspaces.md
+++ b/enterprise/next/04_deploy/01_manage-workspaces.md
@@ -8,15 +8,13 @@ We've designed the Astronomer UI as a place for you to easily and effectively ma
 
 ## Dashboard
 
-Once logged in, you'll land on a dashboard that gives you an overview of your Workspaces. We'll call this the **Account Dashboard**:
+Once logged in, you'll land on a view that will direct you to create a new **Workspace**. From this view, you can:
+
+1. Create a new Workspace
+2. View the Workspaces you have access to in the left-hand navigation
+3. Access "Documentation," "Account Settings" and more in the Account drop-down menu
 
 ![Account Dashboard](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.12-empty-dashboard.png)
-
-From this dashboard, you can:
-
-1. Spin up new Workspaces
-2. View the workspaces you currently have access to
-3. Update your name from the "Account Settings" menu
 
 ## Workspaces
 

--- a/enterprise/next/04_deploy/01_manage-workspaces.md
+++ b/enterprise/next/04_deploy/01_manage-workspaces.md
@@ -49,7 +49,7 @@ Since all of our app activity is routed through a GraphQL API, you're free to cr
 
 A single instance of [Apache Airflow](https://airflow.apache.org/) made up of a scheduler, a webserver, and one or more workers. A deployment has the capacity to host a collection of DAGs.
 
-In the context of Astronomer, the term **Airflow Deployment** is used to describe an instance of Airflow that you've spun up either via our [UI](https://astronomer.io/docs/overview) or [CLI](https://astronomer.io/docs/cli-quickstart) as part of a workspace. Under the hood, each deployment gets its own Kubernetes namespace and has a set isolated resources reserved for itself.
+In the context of Astronomer, the term **Airflow Deployment** is used to describe an instance of Airflow that you've spun up either via the Astronomer UI or [CLI](https://astronomer.io/docs/cli-quickstart) as part of a workspace. Under the hood, each deployment gets its own Kubernetes namespace and has a set isolated resources reserved for itself.
 
 You're able to adjust the resources given to your Airflow deployment directly from the UI. This functionality allows you to choose executor (local or celery) and easily provision additional resources as you scale up.
 

--- a/enterprise/next/04_deploy/01_manage-workspaces.md
+++ b/enterprise/next/04_deploy/01_manage-workspaces.md
@@ -8,7 +8,7 @@ We've designed the Astronomer UI as a place for you to easily and effectively ma
 
 ## Dashboard
 
-Once logged in, you'll land on a dashboard that gives you an overview of your Workspaces. We'll call this the `Account Dashboard`:
+Once logged in, you'll land on a dashboard that gives you an overview of your Workspaces. We'll call this the **Account Dashboard**:
 
 ![Account Dashboard](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.12-empty-dashboard.png)
 
@@ -22,13 +22,13 @@ From this dashboard, you can:
 
 **The Astronomer Workspace:** A personal or shared space that is home to a collection of Airflow deployments. User access to deployments is managed at the workspace level on Astronomer.
 
-A `Workspace` is an Astronomer-specific term. You can think of your workspaces the same way you'd think of teams - they're just collections of Airflow deployments that specific user groups have access to. When you create an account on Astronomer, a default personal workspace is automatically created. Airflow deployments are hierarchically lower - from a workspace, you can create one or more Airflow deployments, and grant or restrict user access to those deployments accordingly.
+A **Workspace** is an Astronomer-specific term. You can think of your workspaces the same way you'd think of teams - they're just collections of Airflow deployments that specific user groups have access to. When you create an account on Astronomer, a default personal workspace is automatically created. Airflow deployments are hierarchically lower - from a workspace, you can create one or more Airflow deployments, and grant or restrict user access to those deployments accordingly.
 
 If you were a solo agent, you could have multiple Airflow deployments within that single workspace and have no need for additional workspaces. Teams, however, often share one or more workspaces labeled as such, and have multiple Airflow deployments from there.
 
 Deployments cannot be used or shared across workspaces. While you’re free to push local DAGs and code anywhere you wish at any time, there is currently no way to move an existing Airflow instance from one workspace to another once deployed.
 
-Once you click into a workspace, you'll land on another dashboard that we'll call the `Workspace Dashboard`:
+Once you click into a workspace, you'll land on another dashboard that we'll call the **Workspace Dashboard**:
 
 ![Workspace Dashboard](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.12-deployments.png)
 
@@ -49,12 +49,12 @@ Since all of our app activity is routed through a GraphQL API, you're free to cr
 
 A single instance of [Apache Airflow](https://airflow.apache.org/) made up of a scheduler, a webserver, and one or more workers. A deployment has the capacity to host a collection of DAGs.
 
-In the context of Astronomer, the term `Airflow Deployment` is used to describe an instance of Airflow that you've spun up either via our [UI](https://astronomer.io/docs/overview) or [CLI](https://astronomer.io/docs/cli-quickstart) as part of a workspace. Under the hood, each deployment gets its own Kubernetes namespace and has a set isolated resources reserved for itself.
+In the context of Astronomer, the term **Airflow Deployment** is used to describe an instance of Airflow that you've spun up either via our [UI](https://astronomer.io/docs/overview) or [CLI](https://astronomer.io/docs/cli-quickstart) as part of a workspace. Under the hood, each deployment gets its own Kubernetes namespace and has a set isolated resources reserved for itself.
 
 You're able to adjust the resources given to your Airflow deployment directly from the UI. This functionality allows you to choose executor (local or celery) and easily provision additional resources as you scale up.
 
 
-From the Workspace dashboard, navigate back to the `Deployments` tab.
+From the Workspace dashboard, navigate back to the "Deployments" tab.
 
 If you click into one of your Airflow deployments, you'll land on a page that looks like this:
 
@@ -63,7 +63,7 @@ If you click into one of your Airflow deployments, you'll land on a page that lo
 From here, you'll be able to access:
 
 1. Airflow UI (DAG Dashboard)
-2. Flower dashboard (if you are running the Celery executor)
+2. Flower Dashboard (if you are running the Celery executor)
 
 The former will link you directly to your DAG Dashboard on Airflow itself. Your Flower Dashboard is your go-to spot to monitor your Celery Workers.
 
@@ -73,8 +73,8 @@ For a breakdown the Airflow UI itself, check out [this guide](https://www.astron
 
 ## User Management
 
-If you navigate over to the `Users` tab of your Workspace Dashboard, you'll be able to see who has access to the Workspace. If you'd like to share access to other members of your organization, invite them to a workspace you're a part of. Once members, they'll have access to _all_ Airflow deployments under that workspace.
+If you navigate over to the "Users" tab of your Workspace Dashboard, you'll be able to see who has access to the Workspace. If you'd like to share access to other members of your organization, invite them to a workspace you're a part of. Once members, they'll have access to _all_ Airflow deployments under that workspace.
 
 ## Workspace Permissions
 
-Users in a Workspace can be given the role of a `Viewer`, `Editor`, or `Admin`. An exact breakdown of these roles can be found in the [User Roles and Permissions](https://www.astronomer.io/docs/rbac/) section. Astronomer Enterprise admins can [configure the exact permissions](https://www.astronomer.io/docs/ee-configuring-permissions/) for each Astronomer role.
+Users in a Workspace can be given the role of a **Viewer**, **Editor**, or **Admin***. An exact breakdown of these roles can be found in the [User Roles and Permissions](https://www.astronomer.io/docs/rbac/) section. Astronomer Enterprise admins can [configure the exact permissions](https://www.astronomer.io/docs/ee-configuring-permissions/) for each Astronomer role.

--- a/enterprise/next/04_deploy/01_manage-workspaces.md
+++ b/enterprise/next/04_deploy/01_manage-workspaces.md
@@ -16,7 +16,7 @@ From this dashboard, you can:
 
 1. Spin up new Workspaces
 2. View the workspaces you currently have access to
-3. Adjust your account name under the `Personal Settings` tab
+3. Update your name from the "Account Settings" menu
 
 ## Workspaces
 

--- a/enterprise/next/04_deploy/02_deploy-code.md
+++ b/enterprise/next/04_deploy/02_deploy-code.md
@@ -19,7 +19,7 @@ To create a deployment on Astronomer, log into the Astronomer UI on either:
 - Astronomer Cloud
 - Your own domain on Astronomer Enterprise (`app.BASEDOMAIN`)
 
-From your Workspace on Astronomer, click `New Deployment`.
+From your Workspace on Astronomer, click "New Deployment".
 
 ![Workspace Dashboard](https://assets2.astronomer.io/main/docs/astronomer-ui/workspace_dashboard.png)
 

--- a/enterprise/next/04_deploy/03_configure-deployment.md
+++ b/enterprise/next/04_deploy/03_configure-deployment.md
@@ -8,12 +8,12 @@ Once you've created your deployment, you can configure it for the use case at ha
 
 ## Allocating Resources
 
-The `Settings` tab allows you to adjust your resource components - empowering you to freely scale your deployment up or down as you wish. To this end, you can:
+The "Settings" tab allows you to adjust your resource components - empowering you to freely scale your deployment up or down as you wish. To this end, you can:
 
 1. Choose your Executor (Local, Celery, or Kubernetes)
 2. Adjust resources to your Scheduler and Webserver
-3. Adjust worker count (*Celery only*)
-4. Adjust your `Worker Termination Grace Period` (*Celery only*)
+3. Adjust Worker Count (*Celery only*)
+4. Adjust your Worker Termination Grace Period (*Celery only*)
 5. Add Extra Capacity (*Kubernetes or KubernetesPodOperator only*)
 
 ![Astro UI Executor Config](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.15-Astro-UI-Executor.png)
@@ -43,7 +43,7 @@ If your Airflow UI is really slow or crashes when you try to load a large DAG, y
 
 ### Extra Capacity
 
-The `Extra Capacity` setting is tied to the [KubernetesPodOperator](https://www.astronomer.io/docs/kubepodoperator/) and the KubernetesExecutor, as it maps to extra pods created in the cluster. Namely, the slider effects:
+The **Extra Capacity** setting is tied to the [KubernetesPodOperator](https://www.astronomer.io/docs/kubepodoperator/) and the KubernetesExecutor, as it maps to extra pods created in the cluster. Namely, the slider effects:
 
 1. CPU and memory quotas
 2. Database connection limits.
@@ -55,9 +55,9 @@ The `Extra Capacity` setting is tied to the [KubernetesPodOperator](https://www.
 Environment Variables are a set of configurable values that allow you to dynamically fine tune your Airflow Deployment. As you think about scaling your use of Airflow, you might consider customizing any of the following Environment Variables:
 
 - `AIRFLOW__CORE__PARALLELISM`
-- `AIRFLOW__CORE__DAG_CONCURRENCY`	
-- `AIRFLOW__CELERY__WORKER_CONCURRENCY`	
-- `AIRFLOW__SCHEDULER__MAX_THREADS`	
+- `AIRFLOW__CORE__DAG_CONCURRENCY`
+- `AIRFLOW__CELERY__WORKER_CONCURRENCY`
+- `AIRFLOW__SCHEDULER__MAX_THREADS`
 
 ![Astro UI Env Vars Config](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.16-Astro-UI-EnvVars.png)
 

--- a/enterprise/next/04_deploy/03_configure-deployment.md
+++ b/enterprise/next/04_deploy/03_configure-deployment.md
@@ -43,7 +43,7 @@ If your Airflow UI is really slow or crashes when you try to load a large DAG, y
 
 ### Extra Capacity
 
-The **Extra Capacity** setting is tied to the [KubernetesPodOperator](https://www.astronomer.io/docs/kubepodoperator/) and the KubernetesExecutor, as it maps to extra pods created in the cluster. Namely, the slider effects:
+The **Extra Capacity** setting is tied to the [KubernetesPodOperator](https://www.astronomer.io/docs/kubepodoperator/) and the KubernetesExecutor, as it maps to extra pods created in the cluster. Namely, the slider affects:
 
 1. CPU and memory quotas
 2. Database connection limits.

--- a/enterprise/next/04_deploy/05_environment-variables.md
+++ b/enterprise/next/04_deploy/05_environment-variables.md
@@ -129,7 +129,7 @@ The last way to add Environment Variables on Astronomer is to add them via the A
 To set them,
 
 1. Navigate to the Astronomer UI
-2. Go to `Deployment` > `Variables`
+2. Go to **Deployment** > **Variables**
 3. Add your Environment Variables
 
 ![Astro UI Env Vars Config](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.16-Astro-UI-EnvVars.png)
@@ -140,32 +140,32 @@ To set them,
 
 On Astronomer, users have the ability to mark any Environment Variable as "secret" via the UI. For those who have Environment Variables containing potentially sensitive information (e.g. SMTP password, S3 bucket, etc.), we'd recommend leveraging this feature.
 
-To do so from the `Variables` tab,
+To do so from the "Variables" tab,
 
 1. Enter a Key
 2. Enter a Value
-3. Check off the `Secret?` box
-4. Click `Add`
-5. Press `Deploy Changes`
+3. Check the "Secret?" box
+4. Click "Add"
+5. Press "Deploy Changes"
 
-Once changes are deployed, Environment Variables marked as 'secret' will NOT be available in plain-text to any user in the Workspace.
+Once changes are deployed, Environment Variables marked as "secret" will NOT be available in plain-text to any user in the Workspace.
 
 A few additional notes:
 
-- Workspace Editors and Admins are free to set an existing non-secret Env Var to 'secret' any time
-- To convert a 'secret' Env Var to a 'non-secret' Env Var, you'll be prompted to enter a new value
-- If you export Environment Variables via JSON, 'secret' values will NOT render in plain-text
+- Workspace Editors and Admins are free to set an existing non-secret Env Var to "secret" any time
+- To convert a "secret" Env Var to a "non-secret" Env Var, you'll be prompted to enter a new value
+- If you export Environment Variables via JSON, "secret" values will NOT render in plain-text
 - Users cannot add a new variable that has the same key as an existing variable
 
 Read below for more detail on how Environment Variables are encrypted on Astronomer.
 
-> **Note:** As noted above, Workspace roles and permissions apply to actions in the `Variables` tab. For a full breakdown of permissions for each role, reference Astronomer's ["Roles and Permissions" doc](https://www.astronomer.io/docs/rbac/).
+> **Note:** As noted above, Workspace roles and permissions apply to actions in the "Variables" tab. For a full breakdown of permissions for each role, reference Astronomer's ["Roles and Permissions" doc](https://www.astronomer.io/docs/rbac/).
 
 ### Precedence amongst 3 Methods
 
 Given the ability to set Environment Variables across 3 different methods potentially simultaneously, it's worth noting the precedence each take.
 
-On Astronomer, Environment Variables will be applied and overriden in the following order:
+On Astronomer, Environment Variables will be applied and overridden in the following order:
 
 1. Astronomer UI
 2. .env (_Local Only_)

--- a/enterprise/next/04_deploy/05_environment-variables.md
+++ b/enterprise/next/04_deploy/05_environment-variables.md
@@ -129,7 +129,7 @@ The last way to add Environment Variables on Astronomer is to add them via the A
 To set them,
 
 1. Navigate to the Astronomer UI
-2. Go to **Deployment** > **Variables**
+2. Go to "Deployment" > "Variables"
 3. Add your Environment Variables
 
 ![Astro UI Env Vars Config](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.16-Astro-UI-EnvVars.png)

--- a/enterprise/next/04_deploy/06_ci-cd.md
+++ b/enterprise/next/04_deploy/06_ci-cd.md
@@ -97,7 +97,7 @@ Upon creating a Service Account, make sure to:
 * Give it a Category (optional)
 * Grant it a User Role
 
-> **Note:** In order for a Service Account to have permission to push code to your Airflow Deployment, it must have either the `Editor` or `Admin` role. For more information on Workspace roles, refer to our ["Roles and Permissions"](https://www.astronomer.io/docs/rbac/) doc.
+> **Note:** In order for a Service Account to have permission to push code to your Airflow Deployment, it must have either the "Editor" or "Admin" role. For more information on Workspace roles, refer to our ["Roles and Permissions"](https://www.astronomer.io/docs/rbac/) doc.
 
 ![Name Service Account](https://assets2.astronomer.io/main/docs/ci-cd/ci-cd-name-service-account.png)
 
@@ -128,7 +128,7 @@ Once you are authenticated you can build, tag and push your Airflow image to the
 
 #### Registry Address
 
-*Registry Address* tells Docker where to push images to. In the case of Astronomer Enterprise, your private registry located at registry.${BASE_DOMAIN}.
+*Registry Address* tells Docker where to push images to. In the case of Astronomer Enterprise, your private registry located at `registry.${BASE_DOMAIN}`.
 
 
 #### Release Name
@@ -137,7 +137,7 @@ Once you are authenticated you can build, tag and push your Airflow image to the
 
 #### Tag Name
 
-*Tag Name*: Each deploy to Astronomer generates a Docker image with a corresponding tag. If you deploy via the CLI, the tag will by default read `deploy-n`, with `n` representing the numnber of deploys made to that Airflow Deployment. If you're using CI/CD, you get to customize this tag. We typically recommend specifying the source and the build number in the name.
+*Tag Name*: Each deploy to Astronomer generates a Docker image with a corresponding tag. If you deploy via the CLI, the tag will by default read `deploy-n`, with `n` representing the number of deploys made to that Airflow Deployment. If you're using CI/CD, you get to customize this tag. We typically recommend specifying the source and the build number in the name.
 
 In the example below, we use the prefix `ci-` and the ENV `${DRONE_BUILD_NUMBER}`. This guarantees that we always know which CI/CD build triggered the build and push.
 

--- a/enterprise/v0.12/02_develop/02_customize-image.md
+++ b/enterprise/v0.12/02_develop/02_customize-image.md
@@ -21,7 +21,7 @@ More specifically, this doc includes instructions for how to:
 
 ## Add Python and OS-level Packages
 
-To build Python and OS-level packages into your Airflow Deployment, add them to your `requirements.txt` and `packages.txt` files on Astronomer. Both files were automatically generated when you intialized an Airflow project locally via `$ astro dev init`. Steps below.
+To build Python and OS-level packages into your Airflow Deployment, add them to your `requirements.txt` and `packages.txt` files on Astronomer. Both files were automatically generated when you initialized an Airflow project locally via `$ astro dev init`. Steps below.
 
 ### Add your Python or OS-Level Package
 

--- a/enterprise/v0.12/04_deploy/01_manage-workspaces.md
+++ b/enterprise/v0.12/04_deploy/01_manage-workspaces.md
@@ -8,15 +8,13 @@ We've designed the Astronomer UI as a place for you to easily and effectively ma
 
 ## Dashboard
 
-Once logged in, you'll land on a dashboard that gives you an overview of your Workspaces. We'll call this the **Account Dashboard**:
+Once logged in, you'll land on a view that will direct you to create a new **Workspace**. From this view, you can:
+
+1. Create a new Workspace
+2. View the Workspaces you have access to in the left-hand navigation
+3. Access "Documentation," "Account Settings" and more in the Account drop-down menu
 
 ![Account Dashboard](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.12-empty-dashboard.png)
-
-From this dashboard, you can:
-
-1. Spin up new Workspaces
-2. View the workspaces you currently have access to
-3. Update your name from the "Account Settings" menu
 
 ## Workspaces
 

--- a/enterprise/v0.12/04_deploy/01_manage-workspaces.md
+++ b/enterprise/v0.12/04_deploy/01_manage-workspaces.md
@@ -49,7 +49,7 @@ Since all of our app activity is routed through a GraphQL API, you're free to cr
 
 A single instance of [Apache Airflow](https://airflow.apache.org/) made up of a scheduler, a webserver, and one or more workers. A deployment has the capacity to host a collection of DAGs.
 
-In the context of Astronomer, the term **Airflow Deployment** is used to describe an instance of Airflow that you've spun up either via our [UI](https://astronomer.io/docs/overview) or [CLI](https://astronomer.io/docs/cli-quickstart) as part of a workspace. Under the hood, each deployment gets its own Kubernetes namespace and has a set isolated resources reserved for itself.
+In the context of Astronomer, the term **Airflow Deployment** is used to describe an instance of Airflow that you've spun up either via the Astronomer UI or [CLI](https://astronomer.io/docs/cli-quickstart) as part of a workspace. Under the hood, each deployment gets its own Kubernetes namespace and has a set isolated resources reserved for itself.
 
 You're able to adjust the resources given to your Airflow deployment directly from the UI. This functionality allows you to choose executor (local or celery) and easily provision additional resources as you scale up.
 

--- a/enterprise/v0.12/04_deploy/01_manage-workspaces.md
+++ b/enterprise/v0.12/04_deploy/01_manage-workspaces.md
@@ -8,7 +8,7 @@ We've designed the Astronomer UI as a place for you to easily and effectively ma
 
 ## Dashboard
 
-Once logged in, you'll land on a dashboard that gives you an overview of your Workspaces. We'll call this the `Account Dashboard`:
+Once logged in, you'll land on a dashboard that gives you an overview of your Workspaces. We'll call this the **Account Dashboard**:
 
 ![Account Dashboard](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.12-empty-dashboard.png)
 
@@ -22,13 +22,13 @@ From this dashboard, you can:
 
 **The Astronomer Workspace:** A personal or shared space that is home to a collection of Airflow deployments. User access to deployments is managed at the workspace level on Astronomer.
 
-A `Workspace` is an Astronomer-specific term. You can think of your workspaces the same way you'd think of teams - they're just collections of Airflow deployments that specific user groups have access to. When you create an account on Astronomer, a default personal workspace is automatically created. Airflow deployments are hierarchically lower - from a workspace, you can create one or more Airflow deployments, and grant or restrict user access to those deployments accordingly.
+A **Workspace** is an Astronomer-specific term. You can think of your workspaces the same way you'd think of teams - they're just collections of Airflow deployments that specific user groups have access to. When you create an account on Astronomer, a default personal workspace is automatically created. Airflow deployments are hierarchically lower - from a workspace, you can create one or more Airflow deployments, and grant or restrict user access to those deployments accordingly.
 
 If you were a solo agent, you could have multiple Airflow deployments within that single workspace and have no need for additional workspaces. Teams, however, often share one or more workspaces labeled as such, and have multiple Airflow deployments from there.
 
 Deployments cannot be used or shared across workspaces. While you’re free to push local DAGs and code anywhere you wish at any time, there is currently no way to move an existing Airflow instance from one workspace to another once deployed.
 
-Once you click into a workspace, you'll land on another dashboard that we'll call the `Workspace Dashboard`:
+Once you click into a workspace, you'll land on another dashboard that we'll call the **Workspace Dashboard**:
 
 ![Workspace Dashboard](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.12-deployments.png)
 
@@ -49,12 +49,12 @@ Since all of our app activity is routed through a GraphQL API, you're free to cr
 
 A single instance of [Apache Airflow](https://airflow.apache.org/) made up of a scheduler, a webserver, and one or more workers. A deployment has the capacity to host a collection of DAGs.
 
-In the context of Astronomer, the term `Airflow Deployment` is used to describe an instance of Airflow that you've spun up either via our [UI](https://astronomer.io/docs/overview) or [CLI](https://astronomer.io/docs/cli-quickstart) as part of a workspace. Under the hood, each deployment gets its own Kubernetes namespace and has a set isolated resources reserved for itself.
+In the context of Astronomer, the term **Airflow Deployment** is used to describe an instance of Airflow that you've spun up either via our [UI](https://astronomer.io/docs/overview) or [CLI](https://astronomer.io/docs/cli-quickstart) as part of a workspace. Under the hood, each deployment gets its own Kubernetes namespace and has a set isolated resources reserved for itself.
 
 You're able to adjust the resources given to your Airflow deployment directly from the UI. This functionality allows you to choose executor (local or celery) and easily provision additional resources as you scale up.
 
 
-From the Workspace dashboard, navigate back to the `Deployments` tab.
+From the Workspace dashboard, navigate back to the "Deployments" tab.
 
 If you click into one of your Airflow deployments, you'll land on a page that looks like this:
 
@@ -63,7 +63,7 @@ If you click into one of your Airflow deployments, you'll land on a page that lo
 From here, you'll be able to access:
 
 1. Airflow UI (DAG Dashboard)
-2. Flower dashboard (if you are running the Celery executor)
+2. Flower Dashboard (if you are running the Celery executor)
 
 The former will link you directly to your DAG Dashboard on Airflow itself. Your Flower Dashboard is your go-to spot to monitor your Celery Workers.
 
@@ -73,8 +73,8 @@ For a breakdown the Airflow UI itself, check out [this guide](https://www.astron
 
 ## User Management
 
-If you navigate over to the `Users` tab of your Workspace Dashboard, you'll be able to see who has access to the Workspace. If you'd like to share access to other members of your organization, invite them to a workspace you're a part of. Once members, they'll have access to _all_ Airflow deployments under that workspace.
+If you navigate over to the "Users" tab of your Workspace Dashboard, you'll be able to see who has access to the Workspace. If you'd like to share access to other members of your organization, invite them to a workspace you're a part of. Once members, they'll have access to _all_ Airflow deployments under that workspace.
 
 ## Workspace Permissions
 
-Users in a Workspace can be given the role of a `Viewer`, `Editor`, or `Admin`. An exact breakdown of these roles can be found in the [User Roles and Permissions](https://www.astronomer.io/docs/rbac/) section. Astronomer Enterprise admins can [configure the exact permissions](https://www.astronomer.io/docs/ee-configuring-permissions/) for each Astronomer role.
+Users in a Workspace can be given the role of a **Viewer**, **Editor**, or **Admin***. An exact breakdown of these roles can be found in the [User Roles and Permissions](https://www.astronomer.io/docs/rbac/) section. Astronomer Enterprise admins can [configure the exact permissions](https://www.astronomer.io/docs/ee-configuring-permissions/) for each Astronomer role.

--- a/enterprise/v0.12/04_deploy/01_manage-workspaces.md
+++ b/enterprise/v0.12/04_deploy/01_manage-workspaces.md
@@ -16,7 +16,7 @@ From this dashboard, you can:
 
 1. Spin up new Workspaces
 2. View the workspaces you currently have access to
-3. Adjust your account name under the `Personal Settings` tab
+3. Update your name from the "Account Settings" menu
 
 ## Workspaces
 

--- a/enterprise/v0.12/04_deploy/02_deploy-code.md
+++ b/enterprise/v0.12/04_deploy/02_deploy-code.md
@@ -19,7 +19,7 @@ To create a deployment on Astronomer, log into the Astronomer UI on either:
 - Astronomer Cloud
 - Your own domain on Astronomer Enterprise (`app.BASEDOMAIN`)
 
-From your Workspace on Astronomer, click `New Deployment`.
+From your Workspace on Astronomer, click "New Deployment".
 
 ![Workspace Dashboard](https://assets2.astronomer.io/main/docs/astronomer-ui/workspace_dashboard.png)
 

--- a/enterprise/v0.12/04_deploy/03_configure-deployment.md
+++ b/enterprise/v0.12/04_deploy/03_configure-deployment.md
@@ -43,7 +43,7 @@ If your Airflow UI is really slow or crashes when you try to load a large DAG, y
 
 ### Extra Capacity
 
-The **Extra Capacity** setting is tied to the [KubernetesPodOperator](https://www.astronomer.io/docs/kubepodoperator/) and the KubernetesExecutor, as it maps to extra pods created in the cluster. Namely, the slider effects:
+The **Extra Capacity** setting is tied to the [KubernetesPodOperator](https://www.astronomer.io/docs/kubepodoperator/) and the KubernetesExecutor, as it maps to extra pods created in the cluster. Namely, the slider affects:
 
 1. CPU and memory quotas
 2. Database connection limits.

--- a/enterprise/v0.12/04_deploy/03_configure-deployment.md
+++ b/enterprise/v0.12/04_deploy/03_configure-deployment.md
@@ -8,12 +8,12 @@ Once you've created your deployment, you can configure it for the use case at ha
 
 ## Allocating Resources
 
-The `Settings` tab allows you to adjust your resource components - empowering you to freely scale your deployment up or down as you wish. To this end, you can:
+The "Settings" tab allows you to adjust your resource components - empowering you to freely scale your deployment up or down as you wish. To this end, you can:
 
 1. Choose your Executor (Local, Celery, or Kubernetes)
 2. Adjust resources to your Scheduler and Webserver
-3. Adjust worker count (*Celery only*)
-4. Adjust your `Worker Termination Grace Period` (*Celery only*)
+3. Adjust Worker Count (*Celery only*)
+4. Adjust your Worker Termination Grace Period (*Celery only*)
 5. Add Extra Capacity (*Kubernetes or KubernetesPodOperator only*)
 
 ![Astro UI Executor Config](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.15-Astro-UI-Executor.png)
@@ -43,7 +43,7 @@ If your Airflow UI is really slow or crashes when you try to load a large DAG, y
 
 ### Extra Capacity
 
-The `Extra Capacity` setting is tied to the [KubernetesPodOperator](https://www.astronomer.io/docs/kubepodoperator/) and the KubernetesExecutor, as it maps to extra pods created in the cluster. Namely, the slider effects:
+The **Extra Capacity** setting is tied to the [KubernetesPodOperator](https://www.astronomer.io/docs/kubepodoperator/) and the KubernetesExecutor, as it maps to extra pods created in the cluster. Namely, the slider effects:
 
 1. CPU and memory quotas
 2. Database connection limits.

--- a/enterprise/v0.12/04_deploy/05_environment-variables.md
+++ b/enterprise/v0.12/04_deploy/05_environment-variables.md
@@ -130,7 +130,7 @@ The last way to add Environment Variables on Astronomer is to add them via the A
 To set them,
 
 1. Navigate to the Astronomer UI
-2. Go to `Deployment` > `Variables`
+2. Go to **Deployment** > **Variables**
 3. Add your Environment Variables
 
 ![Astro UI Env Vars Config](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.16-Astro-UI-EnvVars.png)
@@ -141,32 +141,32 @@ To set them,
 
 On Astronomer, users have the ability to mark any Environment Variable as "secret" via the UI. For those who have Environment Variables containing potentially sensitive information (e.g. SMTP password, S3 bucket, etc.), we'd recommend leveraging this feature.
 
-To do so from the `Variables` tab,
+To do so from the "Variables" tab,
 
 1. Enter a Key
 2. Enter a Value
-3. Check off the `Secret?` box
-4. Click `Add`
-5. Press `Deploy Changes`
+3. Check the "Secret?" box
+4. Click "Add"
+5. Press "Deploy Changes"
 
-Once changes are deployed, Environment Variables marked as 'secret' will NOT be available in plain-text to any user in the Workspace.
+Once changes are deployed, Environment Variables marked as "secret" will NOT be available in plain-text to any user in the Workspace.
 
 A few additional notes:
 
-- Workspace Editors and Admins are free to set an existing non-secret Env Var to 'secret' any time
-- To convert a 'secret' Env Var to a 'non-secret' Env Var, you'll be prompted to enter a new value
-- If you export Environment Variables via JSON, 'secret' values will NOT render in plain-text
+- Workspace Editors and Admins are free to set an existing non-secret Env Var to "secret" any time
+- To convert a "secret" Env Var to a "non-secret" Env Var, you'll be prompted to enter a new value
+- If you export Environment Variables via JSON, "secret" values will NOT render in plain-text
 - Users cannot add a new variable that has the same key as an existing variable
 
 Read below for more detail on how Environment Variables are encrypted on Astronomer.
 
-> **Note:** As noted above, Workspace roles and permissions apply to actions in the `Variables` tab. For a full breakdown of permissions for each role, reference Astronomer's ["Roles and Permissions" doc](https://www.astronomer.io/docs/rbac/).
+> **Note:** As noted above, Workspace roles and permissions apply to actions in the "Variables" tab. For a full breakdown of permissions for each role, reference Astronomer's ["Roles and Permissions" doc](https://www.astronomer.io/docs/rbac/).
 
 ### Precedence amongst 3 Methods
 
 Given the ability to set Environment Variables across 3 different methods potentially simultaneously, it's worth noting the precedence each take.
 
-On Astronomer, Environment Variables will be applied and overriden in the following order:
+On Astronomer, Environment Variables will be applied and overridden in the following order:
 
 1. Astronomer UI
 2. .env (_Local Only_)

--- a/enterprise/v0.12/04_deploy/05_environment-variables.md
+++ b/enterprise/v0.12/04_deploy/05_environment-variables.md
@@ -130,7 +130,7 @@ The last way to add Environment Variables on Astronomer is to add them via the A
 To set them,
 
 1. Navigate to the Astronomer UI
-2. Go to **Deployment** > **Variables**
+2. Go to "Deployment" > "Variables"
 3. Add your Environment Variables
 
 ![Astro UI Env Vars Config](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.16-Astro-UI-EnvVars.png)

--- a/enterprise/v0.12/04_deploy/06_ci-cd.md
+++ b/enterprise/v0.12/04_deploy/06_ci-cd.md
@@ -97,7 +97,7 @@ Upon creating a Service Account, make sure to:
 * Give it a Category (optional)
 * Grant it a User Role
 
-> **Note:** In order for a Service Account to have permission to push code to your Airflow Deployment, it must have either the `Editor` or `Admin` role. For more information on Workspace roles, refer to our ["Roles and Permissions"](https://www.astronomer.io/docs/rbac/) doc.
+> **Note:** In order for a Service Account to have permission to push code to your Airflow Deployment, it must have either the "Editor" or "Admin" role. For more information on Workspace roles, refer to our ["Roles and Permissions"](https://www.astronomer.io/docs/rbac/) doc.
 
 ![Name Service Account](https://assets2.astronomer.io/main/docs/ci-cd/ci-cd-name-service-account.png)
 
@@ -128,7 +128,7 @@ Once you are authenticated you can build, tag and push your Airflow image to the
 
 #### Registry Address
 
-*Registry Address* tells Docker where to push images to. In the case of Astronomer Enterprise, your private registry located at registry.${BASE_DOMAIN}.
+*Registry Address* tells Docker where to push images to. In the case of Astronomer Enterprise, your private registry located at `registry.${BASE_DOMAIN}`.
 
 
 #### Release Name
@@ -137,7 +137,7 @@ Once you are authenticated you can build, tag and push your Airflow image to the
 
 #### Tag Name
 
-*Tag Name*: Each deploy to Astronomer generates a Docker image with a corresponding tag. If you deploy via the CLI, the tag will by default read `deploy-n`, with `n` representing the numnber of deploys made to that Airflow Deployment. If you're using CI/CD, you get to customize this tag. We typically recommend specifying the source and the build number in the name.
+*Tag Name*: Each deploy to Astronomer generates a Docker image with a corresponding tag. If you deploy via the CLI, the tag will by default read `deploy-n`, with `n` representing the number of deploys made to that Airflow Deployment. If you're using CI/CD, you get to customize this tag. We typically recommend specifying the source and the build number in the name.
 
 In the example below, we use the prefix `ci-` and the ENV `${DRONE_BUILD_NUMBER}`. This guarantees that we always know which CI/CD build triggered the build and push.
 

--- a/enterprise/v0.13/02_develop/02_customize-image.md
+++ b/enterprise/v0.13/02_develop/02_customize-image.md
@@ -21,7 +21,7 @@ More specifically, this doc includes instructions for how to:
 
 ## Add Python and OS-level Packages
 
-To build Python and OS-level packages into your Airflow Deployment, add them to your `requirements.txt` and `packages.txt` files on Astronomer. Both files were automatically generated when you intialized an Airflow project locally via `$ astro dev init`. Steps below.
+To build Python and OS-level packages into your Airflow Deployment, add them to your `requirements.txt` and `packages.txt` files on Astronomer. Both files were automatically generated when you initialized an Airflow project locally via `$ astro dev init`. Steps below.
 
 ### Add your Python or OS-Level Package
 

--- a/enterprise/v0.13/04_deploy/01_manage-workspaces.md
+++ b/enterprise/v0.13/04_deploy/01_manage-workspaces.md
@@ -8,15 +8,13 @@ We've designed the Astronomer UI as a place for you to easily and effectively ma
 
 ## Dashboard
 
-Once logged in, you'll land on a dashboard that gives you an overview of your Workspaces. We'll call this the **Account Dashboard**:
+Once logged in, you'll land on a view that will direct you to create a new **Workspace**. From this view, you can:
+
+1. Create a new Workspace
+2. View the Workspaces you have access to in the left-hand navigation
+3. Access "Documentation," "Account Settings" and more in the Account drop-down menu
 
 ![Account Dashboard](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.12-empty-dashboard.png)
-
-From this dashboard, you can:
-
-1. Spin up new Workspaces
-2. View the workspaces you currently have access to
-3. Update your name from the "Account Settings" menu
 
 ## Workspaces
 

--- a/enterprise/v0.13/04_deploy/01_manage-workspaces.md
+++ b/enterprise/v0.13/04_deploy/01_manage-workspaces.md
@@ -49,7 +49,7 @@ Since all of our app activity is routed through a GraphQL API, you're free to cr
 
 A single instance of [Apache Airflow](https://airflow.apache.org/) made up of a scheduler, a webserver, and one or more workers. A deployment has the capacity to host a collection of DAGs.
 
-In the context of Astronomer, the term **Airflow Deployment** is used to describe an instance of Airflow that you've spun up either via our [UI](https://astronomer.io/docs/overview) or [CLI](https://astronomer.io/docs/cli-quickstart) as part of a workspace. Under the hood, each deployment gets its own Kubernetes namespace and has a set isolated resources reserved for itself.
+In the context of Astronomer, the term **Airflow Deployment** is used to describe an instance of Airflow that you've spun up either via the Astronomer UI or [CLI](https://astronomer.io/docs/cli-quickstart) as part of a workspace. Under the hood, each deployment gets its own Kubernetes namespace and has a set isolated resources reserved for itself.
 
 You're able to adjust the resources given to your Airflow deployment directly from the UI. This functionality allows you to choose executor (local or celery) and easily provision additional resources as you scale up.
 

--- a/enterprise/v0.13/04_deploy/01_manage-workspaces.md
+++ b/enterprise/v0.13/04_deploy/01_manage-workspaces.md
@@ -8,7 +8,7 @@ We've designed the Astronomer UI as a place for you to easily and effectively ma
 
 ## Dashboard
 
-Once logged in, you'll land on a dashboard that gives you an overview of your Workspaces. We'll call this the `Account Dashboard`:
+Once logged in, you'll land on a dashboard that gives you an overview of your Workspaces. We'll call this the **Account Dashboard**:
 
 ![Account Dashboard](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.12-empty-dashboard.png)
 
@@ -22,13 +22,13 @@ From this dashboard, you can:
 
 **The Astronomer Workspace:** A personal or shared space that is home to a collection of Airflow deployments. User access to deployments is managed at the workspace level on Astronomer.
 
-A `Workspace` is an Astronomer-specific term. You can think of your workspaces the same way you'd think of teams - they're just collections of Airflow deployments that specific user groups have access to. When you create an account on Astronomer, a default personal workspace is automatically created. Airflow deployments are hierarchically lower - from a workspace, you can create one or more Airflow deployments, and grant or restrict user access to those deployments accordingly.
+A **Workspace** is an Astronomer-specific term. You can think of your workspaces the same way you'd think of teams - they're just collections of Airflow deployments that specific user groups have access to. When you create an account on Astronomer, a default personal workspace is automatically created. Airflow deployments are hierarchically lower - from a workspace, you can create one or more Airflow deployments, and grant or restrict user access to those deployments accordingly.
 
 If you were a solo agent, you could have multiple Airflow deployments within that single workspace and have no need for additional workspaces. Teams, however, often share one or more workspaces labeled as such, and have multiple Airflow deployments from there.
 
 Deployments cannot be used or shared across workspaces. While you’re free to push local DAGs and code anywhere you wish at any time, there is currently no way to move an existing Airflow instance from one workspace to another once deployed.
 
-Once you click into a workspace, you'll land on another dashboard that we'll call the `Workspace Dashboard`:
+Once you click into a workspace, you'll land on another dashboard that we'll call the **Workspace Dashboard**:
 
 ![Workspace Dashboard](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.12-deployments.png)
 
@@ -49,12 +49,12 @@ Since all of our app activity is routed through a GraphQL API, you're free to cr
 
 A single instance of [Apache Airflow](https://airflow.apache.org/) made up of a scheduler, a webserver, and one or more workers. A deployment has the capacity to host a collection of DAGs.
 
-In the context of Astronomer, the term `Airflow Deployment` is used to describe an instance of Airflow that you've spun up either via our [UI](https://astronomer.io/docs/overview) or [CLI](https://astronomer.io/docs/cli-quickstart) as part of a workspace. Under the hood, each deployment gets its own Kubernetes namespace and has a set isolated resources reserved for itself.
+In the context of Astronomer, the term **Airflow Deployment** is used to describe an instance of Airflow that you've spun up either via our [UI](https://astronomer.io/docs/overview) or [CLI](https://astronomer.io/docs/cli-quickstart) as part of a workspace. Under the hood, each deployment gets its own Kubernetes namespace and has a set isolated resources reserved for itself.
 
 You're able to adjust the resources given to your Airflow deployment directly from the UI. This functionality allows you to choose executor (local or celery) and easily provision additional resources as you scale up.
 
 
-From the Workspace dashboard, navigate back to the `Deployments` tab.
+From the Workspace dashboard, navigate back to the "Deployments" tab.
 
 If you click into one of your Airflow deployments, you'll land on a page that looks like this:
 
@@ -63,7 +63,7 @@ If you click into one of your Airflow deployments, you'll land on a page that lo
 From here, you'll be able to access:
 
 1. Airflow UI (DAG Dashboard)
-2. Flower dashboard (if you are running the Celery executor)
+2. Flower Dashboard (if you are running the Celery executor)
 
 The former will link you directly to your DAG Dashboard on Airflow itself. Your Flower Dashboard is your go-to spot to monitor your Celery Workers.
 
@@ -73,8 +73,8 @@ For a breakdown the Airflow UI itself, check out [this guide](https://www.astron
 
 ## User Management
 
-If you navigate over to the `Users` tab of your Workspace Dashboard, you'll be able to see who has access to the Workspace. If you'd like to share access to other members of your organization, invite them to a workspace you're a part of. Once members, they'll have access to _all_ Airflow deployments under that workspace.
+If you navigate over to the "Users" tab of your Workspace Dashboard, you'll be able to see who has access to the Workspace. If you'd like to share access to other members of your organization, invite them to a workspace you're a part of. Once members, they'll have access to _all_ Airflow deployments under that workspace.
 
 ## Workspace Permissions
 
-Users in a Workspace can be given the role of a `Viewer`, `Editor`, or `Admin`. An exact breakdown of these roles can be found in the [User Roles and Permissions](https://www.astronomer.io/docs/rbac/) section. Astronomer Enterprise admins can [configure the exact permissions](https://www.astronomer.io/docs/ee-configuring-permissions/) for each Astronomer role.
+Users in a Workspace can be given the role of a **Viewer**, **Editor**, or **Admin***. An exact breakdown of these roles can be found in the [User Roles and Permissions](https://www.astronomer.io/docs/rbac/) section. Astronomer Enterprise admins can [configure the exact permissions](https://www.astronomer.io/docs/ee-configuring-permissions/) for each Astronomer role.

--- a/enterprise/v0.13/04_deploy/01_manage-workspaces.md
+++ b/enterprise/v0.13/04_deploy/01_manage-workspaces.md
@@ -16,7 +16,7 @@ From this dashboard, you can:
 
 1. Spin up new Workspaces
 2. View the workspaces you currently have access to
-3. Adjust your account name under the `Personal Settings` tab
+3. Update your name from the "Account Settings" menu
 
 ## Workspaces
 

--- a/enterprise/v0.13/04_deploy/02_deploy-code.md
+++ b/enterprise/v0.13/04_deploy/02_deploy-code.md
@@ -19,7 +19,7 @@ To create a deployment on Astronomer, log into the Astronomer UI on either:
 - Astronomer Cloud
 - Your own domain on Astronomer Enterprise (`app.BASEDOMAIN`)
 
-From your Workspace on Astronomer, click `New Deployment`.
+From your Workspace on Astronomer, click "New Deployment".
 
 ![Workspace Dashboard](https://assets2.astronomer.io/main/docs/astronomer-ui/workspace_dashboard.png)
 

--- a/enterprise/v0.13/04_deploy/03_configure-deployment.md
+++ b/enterprise/v0.13/04_deploy/03_configure-deployment.md
@@ -43,7 +43,7 @@ If your Airflow UI is really slow or crashes when you try to load a large DAG, y
 
 ### Extra Capacity
 
-The **Extra Capacity** setting is tied to the [KubernetesPodOperator](https://www.astronomer.io/docs/kubepodoperator/) and the KubernetesExecutor, as it maps to extra pods created in the cluster. Namely, the slider effects:
+The **Extra Capacity** setting is tied to the [KubernetesPodOperator](https://www.astronomer.io/docs/kubepodoperator/) and the KubernetesExecutor, as it maps to extra pods created in the cluster. Namely, the slider affects:
 
 1. CPU and memory quotas
 2. Database connection limits.

--- a/enterprise/v0.13/04_deploy/03_configure-deployment.md
+++ b/enterprise/v0.13/04_deploy/03_configure-deployment.md
@@ -8,12 +8,12 @@ Once you've created your deployment, you can configure it for the use case at ha
 
 ## Allocating Resources
 
-The `Settings` tab allows you to adjust your resource components - empowering you to freely scale your deployment up or down as you wish. To this end, you can:
+The "Settings" tab allows you to adjust your resource components - empowering you to freely scale your deployment up or down as you wish. To this end, you can:
 
 1. Choose your Executor (Local, Celery, or Kubernetes)
 2. Adjust resources to your Scheduler and Webserver
-3. Adjust worker count (*Celery only*)
-4. Adjust your `Worker Termination Grace Period` (*Celery only*)
+3. Adjust Worker Count (*Celery only*)
+4. Adjust your Worker Termination Grace Period (*Celery only*)
 5. Add Extra Capacity (*Kubernetes or KubernetesPodOperator only*)
 
 ![Astro UI Executor Config](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.15-Astro-UI-Executor.png)
@@ -43,7 +43,7 @@ If your Airflow UI is really slow or crashes when you try to load a large DAG, y
 
 ### Extra Capacity
 
-The `Extra Capacity` setting is tied to the [KubernetesPodOperator](https://www.astronomer.io/docs/kubepodoperator/) and the KubernetesExecutor, as it maps to extra pods created in the cluster. Namely, the slider effects:
+The **Extra Capacity** setting is tied to the [KubernetesPodOperator](https://www.astronomer.io/docs/kubepodoperator/) and the KubernetesExecutor, as it maps to extra pods created in the cluster. Namely, the slider effects:
 
 1. CPU and memory quotas
 2. Database connection limits.

--- a/enterprise/v0.13/04_deploy/05_environment-variables.md
+++ b/enterprise/v0.13/04_deploy/05_environment-variables.md
@@ -130,7 +130,7 @@ The last way to add Environment Variables on Astronomer is to add them via the A
 To set them,
 
 1. Navigate to the Astronomer UI
-2. Go to `Deployment` > `Variables`
+2. Go to **Deployment** > **Variables**
 3. Add your Environment Variables
 
 ![Astro UI Env Vars Config](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.16-Astro-UI-EnvVars.png)
@@ -141,32 +141,32 @@ To set them,
 
 On Astronomer, users have the ability to mark any Environment Variable as "secret" via the UI. For those who have Environment Variables containing potentially sensitive information (e.g. SMTP password, S3 bucket, etc.), we'd recommend leveraging this feature.
 
-To do so from the `Variables` tab,
+To do so from the "Variables" tab,
 
 1. Enter a Key
 2. Enter a Value
-3. Check off the `Secret?` box
-4. Click `Add`
-5. Press `Deploy Changes`
+3. Check the "Secret?" box
+4. Click "Add"
+5. Press "Deploy Changes"
 
-Once changes are deployed, Environment Variables marked as 'secret' will NOT be available in plain-text to any user in the Workspace.
+Once changes are deployed, Environment Variables marked as "secret" will NOT be available in plain-text to any user in the Workspace.
 
 A few additional notes:
 
-- Workspace Editors and Admins are free to set an existing non-secret Env Var to 'secret' any time
-- To convert a 'secret' Env Var to a 'non-secret' Env Var, you'll be prompted to enter a new value
-- If you export Environment Variables via JSON, 'secret' values will NOT render in plain-text
+- Workspace Editors and Admins are free to set an existing non-secret Env Var to "secret" any time
+- To convert a "secret" Env Var to a "non-secret" Env Var, you'll be prompted to enter a new value
+- If you export Environment Variables via JSON, "secret" values will NOT render in plain-text
 - Users cannot add a new variable that has the same key as an existing variable
 
 Read below for more detail on how Environment Variables are encrypted on Astronomer.
 
-> **Note:** As noted above, Workspace roles and permissions apply to actions in the `Variables` tab. For a full breakdown of permissions for each role, reference Astronomer's ["Roles and Permissions" doc](https://www.astronomer.io/docs/rbac/).
+> **Note:** As noted above, Workspace roles and permissions apply to actions in the "Variables" tab. For a full breakdown of permissions for each role, reference Astronomer's ["Roles and Permissions" doc](https://www.astronomer.io/docs/rbac/).
 
 ### Precedence amongst 3 Methods
 
 Given the ability to set Environment Variables across 3 different methods potentially simultaneously, it's worth noting the precedence each take.
 
-On Astronomer, Environment Variables will be applied and overriden in the following order:
+On Astronomer, Environment Variables will be applied and overridden in the following order:
 
 1. Astronomer UI
 2. .env (_Local Only_)

--- a/enterprise/v0.13/04_deploy/05_environment-variables.md
+++ b/enterprise/v0.13/04_deploy/05_environment-variables.md
@@ -130,7 +130,7 @@ The last way to add Environment Variables on Astronomer is to add them via the A
 To set them,
 
 1. Navigate to the Astronomer UI
-2. Go to **Deployment** > **Variables**
+2. Go to "Deployment" > "Variables"
 3. Add your Environment Variables
 
 ![Astro UI Env Vars Config](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.16-Astro-UI-EnvVars.png)

--- a/enterprise/v0.13/04_deploy/06_ci-cd.md
+++ b/enterprise/v0.13/04_deploy/06_ci-cd.md
@@ -97,7 +97,7 @@ Upon creating a Service Account, make sure to:
 * Give it a Category (optional)
 * Grant it a User Role
 
-> **Note:** In order for a Service Account to have permission to push code to your Airflow Deployment, it must have either the `Editor` or `Admin` role. For more information on Workspace roles, refer to our ["Roles and Permissions"](https://www.astronomer.io/docs/rbac/) doc.
+> **Note:** In order for a Service Account to have permission to push code to your Airflow Deployment, it must have either the "Editor" or "Admin" role. For more information on Workspace roles, refer to our ["Roles and Permissions"](https://www.astronomer.io/docs/rbac/) doc.
 
 ![Name Service Account](https://assets2.astronomer.io/main/docs/ci-cd/ci-cd-name-service-account.png)
 
@@ -128,7 +128,7 @@ Once you are authenticated you can build, tag and push your Airflow image to the
 
 #### Registry Address
 
-*Registry Address* tells Docker where to push images to. In the case of Astronomer Enterprise, your private registry located at registry.${BASE_DOMAIN}.
+*Registry Address* tells Docker where to push images to. In the case of Astronomer Enterprise, your private registry located at `registry.${BASE_DOMAIN}`.
 
 
 #### Release Name
@@ -137,7 +137,7 @@ Once you are authenticated you can build, tag and push your Airflow image to the
 
 #### Tag Name
 
-*Tag Name*: Each deploy to Astronomer generates a Docker image with a corresponding tag. If you deploy via the CLI, the tag will by default read `deploy-n`, with `n` representing the numnber of deploys made to that Airflow Deployment. If you're using CI/CD, you get to customize this tag. We typically recommend specifying the source and the build number in the name.
+*Tag Name*: Each deploy to Astronomer generates a Docker image with a corresponding tag. If you deploy via the CLI, the tag will by default read `deploy-n`, with `n` representing the number of deploys made to that Airflow Deployment. If you're using CI/CD, you get to customize this tag. We typically recommend specifying the source and the build number in the name.
 
 In the example below, we use the prefix `ci-` and the ENV `${DRONE_BUILD_NUMBER}`. This guarantees that we always know which CI/CD build triggered the build and push.
 

--- a/enterprise/v0.14/02_develop/02_customize-image.md
+++ b/enterprise/v0.14/02_develop/02_customize-image.md
@@ -21,7 +21,7 @@ More specifically, this doc includes instructions for how to:
 
 ## Add Python and OS-level Packages
 
-To build Python and OS-level packages into your Airflow Deployment, add them to your `requirements.txt` and `packages.txt` files on Astronomer. Both files were automatically generated when you intialized an Airflow project locally via `$ astro dev init`. Steps below.
+To build Python and OS-level packages into your Airflow Deployment, add them to your `requirements.txt` and `packages.txt` files on Astronomer. Both files were automatically generated when you initialized an Airflow project locally via `$ astro dev init`. Steps below.
 
 ### Add your Python or OS-Level Package
 

--- a/enterprise/v0.14/04_deploy/01_manage-workspaces.md
+++ b/enterprise/v0.14/04_deploy/01_manage-workspaces.md
@@ -8,15 +8,15 @@ We've designed the Astronomer UI as a place for you to easily and effectively ma
 
 ## Dashboard
 
-Once logged in, you'll land on a dashboard that gives you an overview of your Workspaces. We'll call this the **Account Dashboard**:
+Once logged in, you'll land on a view that will direct you to create a new **Workspace**. From this view, you can:
 
 ![Account Dashboard](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.12-empty-dashboard.png)
 
 From this dashboard, you can:
 
-1. Spin up new Workspaces
-2. View the workspaces you currently have access to
-3. Update your name from the "Account Settings" menu
+1. Create a new Workspace
+2. View the Workspaces you have access to in the left-hand navigation
+3. Access "Documentation," "Account Settings" and more in the Account drop-down menu
 
 ## Workspaces
 

--- a/enterprise/v0.14/04_deploy/01_manage-workspaces.md
+++ b/enterprise/v0.14/04_deploy/01_manage-workspaces.md
@@ -49,7 +49,7 @@ Since all of our app activity is routed through a GraphQL API, you're free to cr
 
 A single instance of [Apache Airflow](https://airflow.apache.org/) made up of a scheduler, a webserver, and one or more workers. A deployment has the capacity to host a collection of DAGs.
 
-In the context of Astronomer, the term **Airflow Deployment** is used to describe an instance of Airflow that you've spun up either via our [UI](https://astronomer.io/docs/overview) or [CLI](https://astronomer.io/docs/cli-quickstart) as part of a workspace. Under the hood, each deployment gets its own Kubernetes namespace and has a set isolated resources reserved for itself.
+In the context of Astronomer, the term **Airflow Deployment** is used to describe an instance of Airflow that you've spun up either via the Astronomer UI or [CLI](https://astronomer.io/docs/cli-quickstart) as part of a workspace. Under the hood, each deployment gets its own Kubernetes namespace and has a set isolated resources reserved for itself.
 
 You're able to adjust the resources given to your Airflow deployment directly from the UI. This functionality allows you to choose executor (local or celery) and easily provision additional resources as you scale up.
 

--- a/enterprise/v0.14/04_deploy/01_manage-workspaces.md
+++ b/enterprise/v0.14/04_deploy/01_manage-workspaces.md
@@ -8,7 +8,7 @@ We've designed the Astronomer UI as a place for you to easily and effectively ma
 
 ## Dashboard
 
-Once logged in, you'll land on a dashboard that gives you an overview of your Workspaces. We'll call this the `Account Dashboard`:
+Once logged in, you'll land on a dashboard that gives you an overview of your Workspaces. We'll call this the **Account Dashboard**:
 
 ![Account Dashboard](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.12-empty-dashboard.png)
 
@@ -22,13 +22,13 @@ From this dashboard, you can:
 
 **The Astronomer Workspace:** A personal or shared space that is home to a collection of Airflow deployments. User access to deployments is managed at the workspace level on Astronomer.
 
-A `Workspace` is an Astronomer-specific term. You can think of your workspaces the same way you'd think of teams - they're just collections of Airflow deployments that specific user groups have access to. When you create an account on Astronomer, a default personal workspace is automatically created. Airflow deployments are hierarchically lower - from a workspace, you can create one or more Airflow deployments, and grant or restrict user access to those deployments accordingly.
+A **Workspace** is an Astronomer-specific term. You can think of your workspaces the same way you'd think of teams - they're just collections of Airflow deployments that specific user groups have access to. When you create an account on Astronomer, a default personal workspace is automatically created. Airflow deployments are hierarchically lower - from a workspace, you can create one or more Airflow deployments, and grant or restrict user access to those deployments accordingly.
 
 If you were a solo agent, you could have multiple Airflow deployments within that single workspace and have no need for additional workspaces. Teams, however, often share one or more workspaces labeled as such, and have multiple Airflow deployments from there.
 
 Deployments cannot be used or shared across workspaces. While you’re free to push local DAGs and code anywhere you wish at any time, there is currently no way to move an existing Airflow instance from one workspace to another once deployed.
 
-Once you click into a workspace, you'll land on another dashboard that we'll call the `Workspace Dashboard`:
+Once you click into a workspace, you'll land on another dashboard that we'll call the **Workspace Dashboard**:
 
 ![Workspace Dashboard](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.12-deployments.png)
 
@@ -49,12 +49,12 @@ Since all of our app activity is routed through a GraphQL API, you're free to cr
 
 A single instance of [Apache Airflow](https://airflow.apache.org/) made up of a scheduler, a webserver, and one or more workers. A deployment has the capacity to host a collection of DAGs.
 
-In the context of Astronomer, the term `Airflow Deployment` is used to describe an instance of Airflow that you've spun up either via our [UI](https://astronomer.io/docs/overview) or [CLI](https://astronomer.io/docs/cli-quickstart) as part of a workspace. Under the hood, each deployment gets its own Kubernetes namespace and has a set isolated resources reserved for itself.
+In the context of Astronomer, the term **Airflow Deployment** is used to describe an instance of Airflow that you've spun up either via our [UI](https://astronomer.io/docs/overview) or [CLI](https://astronomer.io/docs/cli-quickstart) as part of a workspace. Under the hood, each deployment gets its own Kubernetes namespace and has a set isolated resources reserved for itself.
 
 You're able to adjust the resources given to your Airflow deployment directly from the UI. This functionality allows you to choose executor (local or celery) and easily provision additional resources as you scale up.
 
 
-From the Workspace dashboard, navigate back to the `Deployments` tab.
+From the Workspace dashboard, navigate back to the "Deployments" tab.
 
 If you click into one of your Airflow deployments, you'll land on a page that looks like this:
 
@@ -63,7 +63,7 @@ If you click into one of your Airflow deployments, you'll land on a page that lo
 From here, you'll be able to access:
 
 1. Airflow UI (DAG Dashboard)
-2. Flower dashboard (if you are running the Celery executor)
+2. Flower Dashboard (if you are running the Celery executor)
 
 The former will link you directly to your DAG Dashboard on Airflow itself. Your Flower Dashboard is your go-to spot to monitor your Celery Workers.
 
@@ -73,8 +73,8 @@ For a breakdown the Airflow UI itself, check out [this guide](https://www.astron
 
 ## User Management
 
-If you navigate over to the `Users` tab of your Workspace Dashboard, you'll be able to see who has access to the Workspace. If you'd like to share access to other members of your organization, invite them to a workspace you're a part of. Once members, they'll have access to _all_ Airflow deployments under that workspace.
+If you navigate over to the "Users" tab of your Workspace Dashboard, you'll be able to see who has access to the Workspace. If you'd like to share access to other members of your organization, invite them to a workspace you're a part of. Once members, they'll have access to _all_ Airflow deployments under that workspace.
 
 ## Workspace Permissions
 
-Users in a Workspace can be given the role of a `Viewer`, `Editor`, or `Admin`. An exact breakdown of these roles can be found in the [User Roles and Permissions](https://www.astronomer.io/docs/rbac/) section. Astronomer Enterprise admins can [configure the exact permissions](https://www.astronomer.io/docs/ee-configuring-permissions/) for each Astronomer role.
+Users in a Workspace can be given the role of a **Viewer**, **Editor**, or **Admin***. An exact breakdown of these roles can be found in the [User Roles and Permissions](https://www.astronomer.io/docs/rbac/) section. Astronomer Enterprise admins can [configure the exact permissions](https://www.astronomer.io/docs/ee-configuring-permissions/) for each Astronomer role.

--- a/enterprise/v0.14/04_deploy/01_manage-workspaces.md
+++ b/enterprise/v0.14/04_deploy/01_manage-workspaces.md
@@ -16,7 +16,7 @@ From this dashboard, you can:
 
 1. Spin up new Workspaces
 2. View the workspaces you currently have access to
-3. Adjust your account name under the `Personal Settings` tab
+3. Update your name from the "Account Settings" menu
 
 ## Workspaces
 

--- a/enterprise/v0.14/04_deploy/02_deploy-code.md
+++ b/enterprise/v0.14/04_deploy/02_deploy-code.md
@@ -19,7 +19,7 @@ To create a deployment on Astronomer, log into the Astronomer UI on either:
 - Astronomer Cloud
 - Your own domain on Astronomer Enterprise (`app.BASEDOMAIN`)
 
-From your Workspace on Astronomer, click `New Deployment`.
+From your Workspace on Astronomer, click "New Deployment".
 
 ![Workspace Dashboard](https://assets2.astronomer.io/main/docs/astronomer-ui/workspace_dashboard.png)
 

--- a/enterprise/v0.14/04_deploy/03_configure-deployment.md
+++ b/enterprise/v0.14/04_deploy/03_configure-deployment.md
@@ -43,7 +43,7 @@ If your Airflow UI is really slow or crashes when you try to load a large DAG, y
 
 ### Extra Capacity
 
-The **Extra Capacity** setting is tied to the [KubernetesPodOperator](https://www.astronomer.io/docs/kubepodoperator/) and the KubernetesExecutor, as it maps to extra pods created in the cluster. Namely, the slider effects:
+The **Extra Capacity** setting is tied to the [KubernetesPodOperator](https://www.astronomer.io/docs/kubepodoperator/) and the KubernetesExecutor, as it maps to extra pods created in the cluster. Namely, the slider affects:
 
 1. CPU and memory quotas
 2. Database connection limits.

--- a/enterprise/v0.14/04_deploy/03_configure-deployment.md
+++ b/enterprise/v0.14/04_deploy/03_configure-deployment.md
@@ -8,12 +8,12 @@ Once you've created your deployment, you can configure it for the use case at ha
 
 ## Allocating Resources
 
-The `Settings` tab allows you to adjust your resource components - empowering you to freely scale your deployment up or down as you wish. To this end, you can:
+The "Settings" tab allows you to adjust your resource components - empowering you to freely scale your deployment up or down as you wish. To this end, you can:
 
 1. Choose your Executor (Local, Celery, or Kubernetes)
 2. Adjust resources to your Scheduler and Webserver
-3. Adjust worker count (*Celery only*)
-4. Adjust your `Worker Termination Grace Period` (*Celery only*)
+3. Adjust Worker Count (*Celery only*)
+4. Adjust your Worker Termination Grace Period (*Celery only*)
 5. Add Extra Capacity (*Kubernetes or KubernetesPodOperator only*)
 
 ![Astro UI Executor Config](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.15-Astro-UI-Executor.png)
@@ -43,7 +43,7 @@ If your Airflow UI is really slow or crashes when you try to load a large DAG, y
 
 ### Extra Capacity
 
-The `Extra Capacity` setting is tied to the [KubernetesPodOperator](https://www.astronomer.io/docs/kubepodoperator/) and the KubernetesExecutor, as it maps to extra pods created in the cluster. Namely, the slider effects:
+The **Extra Capacity** setting is tied to the [KubernetesPodOperator](https://www.astronomer.io/docs/kubepodoperator/) and the KubernetesExecutor, as it maps to extra pods created in the cluster. Namely, the slider effects:
 
 1. CPU and memory quotas
 2. Database connection limits.

--- a/enterprise/v0.14/04_deploy/05_environment-variables.md
+++ b/enterprise/v0.14/04_deploy/05_environment-variables.md
@@ -130,7 +130,7 @@ The last way to add Environment Variables on Astronomer is to add them via the A
 To set them,
 
 1. Navigate to the Astronomer UI
-2. Go to `Deployment` > `Variables`
+2. Go to **Deployment** > **Variables**
 3. Add your Environment Variables
 
 ![Astro UI Env Vars Config](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.16-Astro-UI-EnvVars.png)
@@ -141,32 +141,32 @@ To set them,
 
 On Astronomer, users have the ability to mark any Environment Variable as "secret" via the UI. For those who have Environment Variables containing potentially sensitive information (e.g. SMTP password, S3 bucket, etc.), we'd recommend leveraging this feature.
 
-To do so from the `Variables` tab,
+To do so from the "Variables" tab,
 
 1. Enter a Key
 2. Enter a Value
-3. Check off the `Secret?` box
-4. Click `Add`
-5. Press `Deploy Changes`
+3. Check the "Secret?" box
+4. Click "Add"
+5. Press "Deploy Changes"
 
-Once changes are deployed, Environment Variables marked as 'secret' will NOT be available in plain-text to any user in the Workspace.
+Once changes are deployed, Environment Variables marked as "secret" will NOT be available in plain-text to any user in the Workspace.
 
 A few additional notes:
 
-- Workspace Editors and Admins are free to set an existing non-secret Env Var to 'secret' any time
-- To convert a 'secret' Env Var to a 'non-secret' Env Var, you'll be prompted to enter a new value
-- If you export Environment Variables via JSON, 'secret' values will NOT render in plain-text
+- Workspace Editors and Admins are free to set an existing non-secret Env Var to "secret" any time
+- To convert a "secret" Env Var to a "non-secret" Env Var, you'll be prompted to enter a new value
+- If you export Environment Variables via JSON, "secret" values will NOT render in plain-text
 - Users cannot add a new variable that has the same key as an existing variable
 
 Read below for more detail on how Environment Variables are encrypted on Astronomer.
 
-> **Note:** As noted above, Workspace roles and permissions apply to actions in the `Variables` tab. For a full breakdown of permissions for each role, reference Astronomer's ["Roles and Permissions" doc](https://www.astronomer.io/docs/rbac/).
+> **Note:** As noted above, Workspace roles and permissions apply to actions in the "Variables" tab. For a full breakdown of permissions for each role, reference Astronomer's ["Roles and Permissions" doc](https://www.astronomer.io/docs/rbac/).
 
 ### Precedence amongst 3 Methods
 
 Given the ability to set Environment Variables across 3 different methods potentially simultaneously, it's worth noting the precedence each take.
 
-On Astronomer, Environment Variables will be applied and overriden in the following order:
+On Astronomer, Environment Variables will be applied and overridden in the following order:
 
 1. Astronomer UI
 2. .env (_Local Only_)

--- a/enterprise/v0.14/04_deploy/05_environment-variables.md
+++ b/enterprise/v0.14/04_deploy/05_environment-variables.md
@@ -130,7 +130,7 @@ The last way to add Environment Variables on Astronomer is to add them via the A
 To set them,
 
 1. Navigate to the Astronomer UI
-2. Go to **Deployment** > **Variables**
+2. Go to "Deployment" > "Variables"
 3. Add your Environment Variables
 
 ![Astro UI Env Vars Config](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.16-Astro-UI-EnvVars.png)

--- a/enterprise/v0.14/04_deploy/06_ci-cd.md
+++ b/enterprise/v0.14/04_deploy/06_ci-cd.md
@@ -97,7 +97,7 @@ Upon creating a Service Account, make sure to:
 * Give it a Category (optional)
 * Grant it a User Role
 
-> **Note:** In order for a Service Account to have permission to push code to your Airflow Deployment, it must have either the `Editor` or `Admin` role. For more information on Workspace roles, refer to our ["Roles and Permissions"](https://www.astronomer.io/docs/rbac/) doc.
+> **Note:** In order for a Service Account to have permission to push code to your Airflow Deployment, it must have either the "Editor" or "Admin" role. For more information on Workspace roles, refer to our ["Roles and Permissions"](https://www.astronomer.io/docs/rbac/) doc.
 
 ![Name Service Account](https://assets2.astronomer.io/main/docs/ci-cd/ci-cd-name-service-account.png)
 
@@ -128,7 +128,7 @@ Once you are authenticated you can build, tag and push your Airflow image to the
 
 #### Registry Address
 
-*Registry Address* tells Docker where to push images to. In the case of Astronomer Enterprise, your private registry located at registry.${BASE_DOMAIN}.
+*Registry Address* tells Docker where to push images to. In the case of Astronomer Enterprise, your private registry located at `registry.${BASE_DOMAIN}`.
 
 
 #### Release Name
@@ -137,7 +137,7 @@ Once you are authenticated you can build, tag and push your Airflow image to the
 
 #### Tag Name
 
-*Tag Name*: Each deploy to Astronomer generates a Docker image with a corresponding tag. If you deploy via the CLI, the tag will by default read `deploy-n`, with `n` representing the numnber of deploys made to that Airflow Deployment. If you're using CI/CD, you get to customize this tag. We typically recommend specifying the source and the build number in the name.
+*Tag Name*: Each deploy to Astronomer generates a Docker image with a corresponding tag. If you deploy via the CLI, the tag will by default read `deploy-n`, with `n` representing the number of deploys made to that Airflow Deployment. If you're using CI/CD, you get to customize this tag. We typically recommend specifying the source and the build number in the name.
 
 In the example below, we use the prefix `ci-` and the ENV `${DRONE_BUILD_NUMBER}`. This guarantees that we always know which CI/CD build triggered the build and push.
 

--- a/enterprise/v0.15/02_develop/02_customize-image.md
+++ b/enterprise/v0.15/02_develop/02_customize-image.md
@@ -21,7 +21,7 @@ More specifically, this doc includes instructions for how to:
 
 ## Add Python and OS-level Packages
 
-To build Python and OS-level packages into your Airflow Deployment, add them to your `requirements.txt` and `packages.txt` files on Astronomer. Both files were automatically generated when you intialized an Airflow project locally via `$ astro dev init`. Steps below.
+To build Python and OS-level packages into your Airflow Deployment, add them to your `requirements.txt` and `packages.txt` files on Astronomer. Both files were automatically generated when you initialized an Airflow project locally via `$ astro dev init`. Steps below.
 
 ### Add your Python or OS-Level Package
 

--- a/enterprise/v0.15/04_deploy/01_manage-workspaces.md
+++ b/enterprise/v0.15/04_deploy/01_manage-workspaces.md
@@ -8,15 +8,15 @@ We've designed the Astronomer UI as a place for you to easily and effectively ma
 
 ## Dashboard
 
-Once logged in, you'll land on a dashboard that gives you an overview of your Workspaces. We'll call this the **Account Dashboard**:
+Once logged in, you'll land on a view that will direct you to create a new **Workspace**. From this view, you can:
 
 ![Account Dashboard](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.12-empty-dashboard.png)
 
 From this dashboard, you can:
 
-1. Spin up new Workspaces
-2. View the workspaces you currently have access to
-3. Update your name from the "Account Settings" menu
+1. Create a new Workspace
+2. View the Workspaces you have access to in the left-hand navigation
+3. Access "Documentation," "Account Settings" and more in the Account drop-down menu
 
 ## Workspaces
 

--- a/enterprise/v0.15/04_deploy/01_manage-workspaces.md
+++ b/enterprise/v0.15/04_deploy/01_manage-workspaces.md
@@ -49,7 +49,7 @@ Since all of our app activity is routed through a GraphQL API, you're free to cr
 
 A single instance of [Apache Airflow](https://airflow.apache.org/) made up of a scheduler, a webserver, and one or more workers. A deployment has the capacity to host a collection of DAGs.
 
-In the context of Astronomer, the term **Airflow Deployment** is used to describe an instance of Airflow that you've spun up either via our [UI](https://astronomer.io/docs/overview) or [CLI](https://astronomer.io/docs/cli-quickstart) as part of a workspace. Under the hood, each deployment gets its own Kubernetes namespace and has a set isolated resources reserved for itself.
+In the context of Astronomer, the term **Airflow Deployment** is used to describe an instance of Airflow that you've spun up either via the Astronomer UI or [CLI](https://astronomer.io/docs/cli-quickstart) as part of a workspace. Under the hood, each deployment gets its own Kubernetes namespace and has a set isolated resources reserved for itself.
 
 You're able to adjust the resources given to your Airflow deployment directly from the UI. This functionality allows you to choose executor (local or celery) and easily provision additional resources as you scale up.
 

--- a/enterprise/v0.15/04_deploy/01_manage-workspaces.md
+++ b/enterprise/v0.15/04_deploy/01_manage-workspaces.md
@@ -8,7 +8,7 @@ We've designed the Astronomer UI as a place for you to easily and effectively ma
 
 ## Dashboard
 
-Once logged in, you'll land on a dashboard that gives you an overview of your Workspaces. We'll call this the `Account Dashboard`:
+Once logged in, you'll land on a dashboard that gives you an overview of your Workspaces. We'll call this the **Account Dashboard**:
 
 ![Account Dashboard](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.12-empty-dashboard.png)
 
@@ -22,13 +22,13 @@ From this dashboard, you can:
 
 **The Astronomer Workspace:** A personal or shared space that is home to a collection of Airflow deployments. User access to deployments is managed at the workspace level on Astronomer.
 
-A `Workspace` is an Astronomer-specific term. You can think of your workspaces the same way you'd think of teams - they're just collections of Airflow deployments that specific user groups have access to. When you create an account on Astronomer, a default personal workspace is automatically created. Airflow deployments are hierarchically lower - from a workspace, you can create one or more Airflow deployments, and grant or restrict user access to those deployments accordingly.
+A **Workspace** is an Astronomer-specific term. You can think of your workspaces the same way you'd think of teams - they're just collections of Airflow deployments that specific user groups have access to. When you create an account on Astronomer, a default personal workspace is automatically created. Airflow deployments are hierarchically lower - from a workspace, you can create one or more Airflow deployments, and grant or restrict user access to those deployments accordingly.
 
 If you were a solo agent, you could have multiple Airflow deployments within that single workspace and have no need for additional workspaces. Teams, however, often share one or more workspaces labeled as such, and have multiple Airflow deployments from there.
 
 Deployments cannot be used or shared across workspaces. While you’re free to push local DAGs and code anywhere you wish at any time, there is currently no way to move an existing Airflow instance from one workspace to another once deployed.
 
-Once you click into a workspace, you'll land on another dashboard that we'll call the `Workspace Dashboard`:
+Once you click into a workspace, you'll land on another dashboard that we'll call the **Workspace Dashboard**:
 
 ![Workspace Dashboard](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.12-deployments.png)
 
@@ -49,12 +49,12 @@ Since all of our app activity is routed through a GraphQL API, you're free to cr
 
 A single instance of [Apache Airflow](https://airflow.apache.org/) made up of a scheduler, a webserver, and one or more workers. A deployment has the capacity to host a collection of DAGs.
 
-In the context of Astronomer, the term `Airflow Deployment` is used to describe an instance of Airflow that you've spun up either via our [UI](https://astronomer.io/docs/overview) or [CLI](https://astronomer.io/docs/cli-quickstart) as part of a workspace. Under the hood, each deployment gets its own Kubernetes namespace and has a set isolated resources reserved for itself.
+In the context of Astronomer, the term **Airflow Deployment** is used to describe an instance of Airflow that you've spun up either via our [UI](https://astronomer.io/docs/overview) or [CLI](https://astronomer.io/docs/cli-quickstart) as part of a workspace. Under the hood, each deployment gets its own Kubernetes namespace and has a set isolated resources reserved for itself.
 
 You're able to adjust the resources given to your Airflow deployment directly from the UI. This functionality allows you to choose executor (local or celery) and easily provision additional resources as you scale up.
 
 
-From the Workspace dashboard, navigate back to the `Deployments` tab.
+From the Workspace dashboard, navigate back to the "Deployments" tab.
 
 If you click into one of your Airflow deployments, you'll land on a page that looks like this:
 
@@ -63,7 +63,7 @@ If you click into one of your Airflow deployments, you'll land on a page that lo
 From here, you'll be able to access:
 
 1. Airflow UI (DAG Dashboard)
-2. Flower dashboard (if you are running the Celery executor)
+2. Flower Dashboard (if you are running the Celery executor)
 
 The former will link you directly to your DAG Dashboard on Airflow itself. Your Flower Dashboard is your go-to spot to monitor your Celery Workers.
 
@@ -73,8 +73,8 @@ For a breakdown the Airflow UI itself, check out [this guide](https://www.astron
 
 ## User Management
 
-If you navigate over to the `Users` tab of your Workspace Dashboard, you'll be able to see who has access to the Workspace. If you'd like to share access to other members of your organization, invite them to a workspace you're a part of. Once members, they'll have access to _all_ Airflow deployments under that workspace.
+If you navigate over to the "Users" tab of your Workspace Dashboard, you'll be able to see who has access to the Workspace. If you'd like to share access to other members of your organization, invite them to a workspace you're a part of. Once members, they'll have access to _all_ Airflow deployments under that workspace.
 
 ## Workspace Permissions
 
-Users in a Workspace can be given the role of a `Viewer`, `Editor`, or `Admin`. An exact breakdown of these roles can be found in the [User Roles and Permissions](https://www.astronomer.io/docs/rbac/) section. Astronomer Enterprise admins can [configure the exact permissions](https://www.astronomer.io/docs/ee-configuring-permissions/) for each Astronomer role.
+Users in a Workspace can be given the role of a **Viewer**, **Editor**, or **Admin***. An exact breakdown of these roles can be found in the [User Roles and Permissions](https://www.astronomer.io/docs/rbac/) section. Astronomer Enterprise admins can [configure the exact permissions](https://www.astronomer.io/docs/ee-configuring-permissions/) for each Astronomer role.

--- a/enterprise/v0.15/04_deploy/01_manage-workspaces.md
+++ b/enterprise/v0.15/04_deploy/01_manage-workspaces.md
@@ -16,7 +16,7 @@ From this dashboard, you can:
 
 1. Spin up new Workspaces
 2. View the workspaces you currently have access to
-3. Adjust your account name under the `Personal Settings` tab
+3. Update your name from the "Account Settings" menu
 
 ## Workspaces
 

--- a/enterprise/v0.15/04_deploy/02_deploy-code.md
+++ b/enterprise/v0.15/04_deploy/02_deploy-code.md
@@ -19,7 +19,7 @@ To create a deployment on Astronomer, log into the Astronomer UI on either:
 - Astronomer Cloud
 - Your own domain on Astronomer Enterprise (`app.BASEDOMAIN`)
 
-From your Workspace on Astronomer, click `New Deployment`.
+From your Workspace on Astronomer, click "New Deployment".
 
 ![Workspace Dashboard](https://assets2.astronomer.io/main/docs/astronomer-ui/workspace_dashboard.png)
 

--- a/enterprise/v0.15/04_deploy/03_configure-deployment.md
+++ b/enterprise/v0.15/04_deploy/03_configure-deployment.md
@@ -43,7 +43,7 @@ If your Airflow UI is really slow or crashes when you try to load a large DAG, y
 
 ### Extra Capacity
 
-The **Extra Capacity** setting is tied to the [KubernetesPodOperator](https://www.astronomer.io/docs/kubepodoperator/) and the KubernetesExecutor, as it maps to extra pods created in the cluster. Namely, the slider effects:
+The **Extra Capacity** setting is tied to the [KubernetesPodOperator](https://www.astronomer.io/docs/kubepodoperator/) and the KubernetesExecutor, as it maps to extra pods created in the cluster. Namely, the slider affects:
 
 1. CPU and memory quotas
 2. Database connection limits.

--- a/enterprise/v0.15/04_deploy/03_configure-deployment.md
+++ b/enterprise/v0.15/04_deploy/03_configure-deployment.md
@@ -8,12 +8,12 @@ Once you've created your deployment, you can configure it for the use case at ha
 
 ## Allocating Resources
 
-The `Settings` tab allows you to adjust your resource components - empowering you to freely scale your deployment up or down as you wish. To this end, you can:
+The "Settings" tab allows you to adjust your resource components - empowering you to freely scale your deployment up or down as you wish. To this end, you can:
 
 1. Choose your Executor (Local, Celery, or Kubernetes)
 2. Adjust resources to your Scheduler and Webserver
-3. Adjust worker count (*Celery only*)
-4. Adjust your `Worker Termination Grace Period` (*Celery only*)
+3. Adjust Worker Count (*Celery only*)
+4. Adjust your Worker Termination Grace Period (*Celery only*)
 5. Add Extra Capacity (*Kubernetes or KubernetesPodOperator only*)
 
 ![Astro UI Executor Config](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.15-Astro-UI-Executor.png)
@@ -43,7 +43,7 @@ If your Airflow UI is really slow or crashes when you try to load a large DAG, y
 
 ### Extra Capacity
 
-The `Extra Capacity` setting is tied to the [KubernetesPodOperator](https://www.astronomer.io/docs/kubepodoperator/) and the KubernetesExecutor, as it maps to extra pods created in the cluster. Namely, the slider effects:
+The **Extra Capacity** setting is tied to the [KubernetesPodOperator](https://www.astronomer.io/docs/kubepodoperator/) and the KubernetesExecutor, as it maps to extra pods created in the cluster. Namely, the slider effects:
 
 1. CPU and memory quotas
 2. Database connection limits.

--- a/enterprise/v0.15/04_deploy/05_environment-variables.md
+++ b/enterprise/v0.15/04_deploy/05_environment-variables.md
@@ -130,7 +130,7 @@ The last way to add Environment Variables on Astronomer is to add them via the A
 To set them,
 
 1. Navigate to the Astronomer UI
-2. Go to `Deployment` > `Variables`
+2. Go to **Deployment** > **Variables**
 3. Add your Environment Variables
 
 ![Astro UI Env Vars Config](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.16-Astro-UI-EnvVars.png)
@@ -141,32 +141,32 @@ To set them,
 
 On Astronomer, users have the ability to mark any Environment Variable as "secret" via the UI. For those who have Environment Variables containing potentially sensitive information (e.g. SMTP password, S3 bucket, etc.), we'd recommend leveraging this feature.
 
-To do so from the `Variables` tab,
+To do so from the "Variables" tab,
 
 1. Enter a Key
 2. Enter a Value
-3. Check off the `Secret?` box
-4. Click `Add`
-5. Press `Deploy Changes`
+3. Check the "Secret?" box
+4. Click "Add"
+5. Press "Deploy Changes"
 
-Once changes are deployed, Environment Variables marked as 'secret' will NOT be available in plain-text to any user in the Workspace.
+Once changes are deployed, Environment Variables marked as "secret" will NOT be available in plain-text to any user in the Workspace.
 
 A few additional notes:
 
-- Workspace Editors and Admins are free to set an existing non-secret Env Var to 'secret' any time
-- To convert a 'secret' Env Var to a 'non-secret' Env Var, you'll be prompted to enter a new value
-- If you export Environment Variables via JSON, 'secret' values will NOT render in plain-text
+- Workspace Editors and Admins are free to set an existing non-secret Env Var to "secret" any time
+- To convert a "secret" Env Var to a "non-secret" Env Var, you'll be prompted to enter a new value
+- If you export Environment Variables via JSON, "secret" values will NOT render in plain-text
 - Users cannot add a new variable that has the same key as an existing variable
 
 Read below for more detail on how Environment Variables are encrypted on Astronomer.
 
-> **Note:** As noted above, Workspace roles and permissions apply to actions in the `Variables` tab. For a full breakdown of permissions for each role, reference Astronomer's ["Roles and Permissions" doc](https://www.astronomer.io/docs/rbac/).
+> **Note:** As noted above, Workspace roles and permissions apply to actions in the "Variables" tab. For a full breakdown of permissions for each role, reference Astronomer's ["Roles and Permissions" doc](https://www.astronomer.io/docs/rbac/).
 
 ### Precedence amongst 3 Methods
 
 Given the ability to set Environment Variables across 3 different methods potentially simultaneously, it's worth noting the precedence each take.
 
-On Astronomer, Environment Variables will be applied and overriden in the following order:
+On Astronomer, Environment Variables will be applied and overridden in the following order:
 
 1. Astronomer UI
 2. .env (_Local Only_)

--- a/enterprise/v0.15/04_deploy/05_environment-variables.md
+++ b/enterprise/v0.15/04_deploy/05_environment-variables.md
@@ -130,7 +130,7 @@ The last way to add Environment Variables on Astronomer is to add them via the A
 To set them,
 
 1. Navigate to the Astronomer UI
-2. Go to **Deployment** > **Variables**
+2. Go to "Deployment" > "Variables"
 3. Add your Environment Variables
 
 ![Astro UI Env Vars Config](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.16-Astro-UI-EnvVars.png)

--- a/enterprise/v0.15/04_deploy/06_ci-cd.md
+++ b/enterprise/v0.15/04_deploy/06_ci-cd.md
@@ -97,7 +97,7 @@ Upon creating a Service Account, make sure to:
 * Give it a Category (optional)
 * Grant it a User Role
 
-> **Note:** In order for a Service Account to have permission to push code to your Airflow Deployment, it must have either the `Editor` or `Admin` role. For more information on Workspace roles, refer to our ["Roles and Permissions"](https://www.astronomer.io/docs/rbac/) doc.
+> **Note:** In order for a Service Account to have permission to push code to your Airflow Deployment, it must have either the "Editor" or "Admin" role. For more information on Workspace roles, refer to our ["Roles and Permissions"](https://www.astronomer.io/docs/rbac/) doc.
 
 ![Name Service Account](https://assets2.astronomer.io/main/docs/ci-cd/ci-cd-name-service-account.png)
 
@@ -128,7 +128,7 @@ Once you are authenticated you can build, tag and push your Airflow image to the
 
 #### Registry Address
 
-*Registry Address* tells Docker where to push images to. In the case of Astronomer Enterprise, your private registry located at registry.${BASE_DOMAIN}.
+*Registry Address* tells Docker where to push images to. In the case of Astronomer Enterprise, your private registry located at `registry.${BASE_DOMAIN}`.
 
 
 #### Release Name
@@ -137,7 +137,7 @@ Once you are authenticated you can build, tag and push your Airflow image to the
 
 #### Tag Name
 
-*Tag Name*: Each deploy to Astronomer generates a Docker image with a corresponding tag. If you deploy via the CLI, the tag will by default read `deploy-n`, with `n` representing the numnber of deploys made to that Airflow Deployment. If you're using CI/CD, you get to customize this tag. We typically recommend specifying the source and the build number in the name.
+*Tag Name*: Each deploy to Astronomer generates a Docker image with a corresponding tag. If you deploy via the CLI, the tag will by default read `deploy-n`, with `n` representing the number of deploys made to that Airflow Deployment. If you're using CI/CD, you get to customize this tag. We typically recommend specifying the source and the build number in the name.
 
 In the example below, we use the prefix `ci-` and the ENV `${DRONE_BUILD_NUMBER}`. This guarantees that we always know which CI/CD build triggered the build and push.
 

--- a/enterprise/v0.16/02_develop/02_customize-image.md
+++ b/enterprise/v0.16/02_develop/02_customize-image.md
@@ -21,7 +21,7 @@ More specifically, this doc includes instructions for how to:
 
 ## Add Python and OS-level Packages
 
-To build Python and OS-level packages into your Airflow Deployment, add them to your `requirements.txt` and `packages.txt` files on Astronomer. Both files were automatically generated when you intialized an Airflow project locally via `$ astro dev init`. Steps below.
+To build Python and OS-level packages into your Airflow Deployment, add them to your `requirements.txt` and `packages.txt` files on Astronomer. Both files were automatically generated when you initialized an Airflow project locally via `$ astro dev init`. Steps below.
 
 ### Add your Python or OS-Level Package
 

--- a/enterprise/v0.16/04_deploy/01_manage-workspaces.md
+++ b/enterprise/v0.16/04_deploy/01_manage-workspaces.md
@@ -8,15 +8,15 @@ We've designed the Astronomer UI as a place for you to easily and effectively ma
 
 ## Dashboard
 
-Once logged in, you'll land on a dashboard that gives you an overview of your Workspaces. We'll call this the **Account Dashboard**:
+Once logged in, you'll land on a view that will direct you to create a new **Workspace**. From this view, you can:
 
 ![Account Dashboard](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.12-empty-dashboard.png)
 
 From this dashboard, you can:
 
-1. Spin up new Workspaces
-2. View the workspaces you currently have access to
-3. Update your name from the "Account Settings" menu
+1. Create a new Workspace
+2. View the Workspaces you have access to in the left-hand navigation
+3. Access "Documentation," "Account Settings" and more in the Account drop-down menu
 
 ## Workspaces
 

--- a/enterprise/v0.16/04_deploy/01_manage-workspaces.md
+++ b/enterprise/v0.16/04_deploy/01_manage-workspaces.md
@@ -49,7 +49,7 @@ Since all of our app activity is routed through a GraphQL API, you're free to cr
 
 A single instance of [Apache Airflow](https://airflow.apache.org/) made up of a scheduler, a webserver, and one or more workers. A deployment has the capacity to host a collection of DAGs.
 
-In the context of Astronomer, the term **Airflow Deployment** is used to describe an instance of Airflow that you've spun up either via our [UI](https://astronomer.io/docs/overview) or [CLI](https://astronomer.io/docs/cli-quickstart) as part of a workspace. Under the hood, each deployment gets its own Kubernetes namespace and has a set isolated resources reserved for itself.
+In the context of Astronomer, the term **Airflow Deployment** is used to describe an instance of Airflow that you've spun up either via the Astronomer UI or [CLI](https://astronomer.io/docs/cli-quickstart) as part of a workspace. Under the hood, each deployment gets its own Kubernetes namespace and has a set isolated resources reserved for itself.
 
 You're able to adjust the resources given to your Airflow deployment directly from the UI. This functionality allows you to choose executor (local or celery) and easily provision additional resources as you scale up.
 

--- a/enterprise/v0.16/04_deploy/01_manage-workspaces.md
+++ b/enterprise/v0.16/04_deploy/01_manage-workspaces.md
@@ -8,7 +8,7 @@ We've designed the Astronomer UI as a place for you to easily and effectively ma
 
 ## Dashboard
 
-Once logged in, you'll land on a dashboard that gives you an overview of your Workspaces. We'll call this the `Account Dashboard`:
+Once logged in, you'll land on a dashboard that gives you an overview of your Workspaces. We'll call this the **Account Dashboard**:
 
 ![Account Dashboard](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.12-empty-dashboard.png)
 
@@ -22,13 +22,13 @@ From this dashboard, you can:
 
 **The Astronomer Workspace:** A personal or shared space that is home to a collection of Airflow deployments. User access to deployments is managed at the workspace level on Astronomer.
 
-A `Workspace` is an Astronomer-specific term. You can think of your workspaces the same way you'd think of teams - they're just collections of Airflow deployments that specific user groups have access to. When you create an account on Astronomer, a default personal workspace is automatically created. Airflow deployments are hierarchically lower - from a workspace, you can create one or more Airflow deployments, and grant or restrict user access to those deployments accordingly.
+A **Workspace** is an Astronomer-specific term. You can think of your workspaces the same way you'd think of teams - they're just collections of Airflow deployments that specific user groups have access to. When you create an account on Astronomer, a default personal workspace is automatically created. Airflow deployments are hierarchically lower - from a workspace, you can create one or more Airflow deployments, and grant or restrict user access to those deployments accordingly.
 
 If you were a solo agent, you could have multiple Airflow deployments within that single workspace and have no need for additional workspaces. Teams, however, often share one or more workspaces labeled as such, and have multiple Airflow deployments from there.
 
 Deployments cannot be used or shared across workspaces. While you’re free to push local DAGs and code anywhere you wish at any time, there is currently no way to move an existing Airflow instance from one workspace to another once deployed.
 
-Once you click into a workspace, you'll land on another dashboard that we'll call the `Workspace Dashboard`:
+Once you click into a workspace, you'll land on another dashboard that we'll call the **Workspace Dashboard**:
 
 ![Workspace Dashboard](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.12-deployments.png)
 
@@ -49,12 +49,12 @@ Since all of our app activity is routed through a GraphQL API, you're free to cr
 
 A single instance of [Apache Airflow](https://airflow.apache.org/) made up of a scheduler, a webserver, and one or more workers. A deployment has the capacity to host a collection of DAGs.
 
-In the context of Astronomer, the term `Airflow Deployment` is used to describe an instance of Airflow that you've spun up either via our [UI](https://astronomer.io/docs/overview) or [CLI](https://astronomer.io/docs/cli-quickstart) as part of a workspace. Under the hood, each deployment gets its own Kubernetes namespace and has a set isolated resources reserved for itself.
+In the context of Astronomer, the term **Airflow Deployment** is used to describe an instance of Airflow that you've spun up either via our [UI](https://astronomer.io/docs/overview) or [CLI](https://astronomer.io/docs/cli-quickstart) as part of a workspace. Under the hood, each deployment gets its own Kubernetes namespace and has a set isolated resources reserved for itself.
 
 You're able to adjust the resources given to your Airflow deployment directly from the UI. This functionality allows you to choose executor (local or celery) and easily provision additional resources as you scale up.
 
 
-From the Workspace dashboard, navigate back to the `Deployments` tab.
+From the Workspace dashboard, navigate back to the "Deployments" tab.
 
 If you click into one of your Airflow deployments, you'll land on a page that looks like this:
 
@@ -63,7 +63,7 @@ If you click into one of your Airflow deployments, you'll land on a page that lo
 From here, you'll be able to access:
 
 1. Airflow UI (DAG Dashboard)
-2. Flower dashboard (if you are running the Celery executor)
+2. Flower Dashboard (if you are running the Celery executor)
 
 The former will link you directly to your DAG Dashboard on Airflow itself. Your Flower Dashboard is your go-to spot to monitor your Celery Workers.
 
@@ -73,8 +73,8 @@ For a breakdown the Airflow UI itself, check out [this guide](https://www.astron
 
 ## User Management
 
-If you navigate over to the `Users` tab of your Workspace Dashboard, you'll be able to see who has access to the Workspace. If you'd like to share access to other members of your organization, invite them to a workspace you're a part of. Once members, they'll have access to _all_ Airflow deployments under that workspace.
+If you navigate over to the "Users" tab of your Workspace Dashboard, you'll be able to see who has access to the Workspace. If you'd like to share access to other members of your organization, invite them to a workspace you're a part of. Once members, they'll have access to _all_ Airflow deployments under that workspace.
 
 ## Workspace Permissions
 
-Users in a Workspace can be given the role of a `Viewer`, `Editor`, or `Admin`. An exact breakdown of these roles can be found in the [User Roles and Permissions](https://www.astronomer.io/docs/rbac/) section. Astronomer Enterprise admins can [configure the exact permissions](https://www.astronomer.io/docs/ee-configuring-permissions/) for each Astronomer role.
+Users in a Workspace can be given the role of a **Viewer**, **Editor**, or **Admin***. An exact breakdown of these roles can be found in the [User Roles and Permissions](https://www.astronomer.io/docs/rbac/) section. Astronomer Enterprise admins can [configure the exact permissions](https://www.astronomer.io/docs/ee-configuring-permissions/) for each Astronomer role.

--- a/enterprise/v0.16/04_deploy/01_manage-workspaces.md
+++ b/enterprise/v0.16/04_deploy/01_manage-workspaces.md
@@ -16,7 +16,7 @@ From this dashboard, you can:
 
 1. Spin up new Workspaces
 2. View the workspaces you currently have access to
-3. Adjust your account name under the `Personal Settings` tab
+3. Update your name from the "Account Settings" menu
 
 ## Workspaces
 

--- a/enterprise/v0.16/04_deploy/02_deploy-code.md
+++ b/enterprise/v0.16/04_deploy/02_deploy-code.md
@@ -19,7 +19,7 @@ To create a deployment on Astronomer, log into the Astronomer UI on either:
 - Astronomer Cloud
 - Your own domain on Astronomer Enterprise (`app.BASEDOMAIN`)
 
-From your Workspace on Astronomer, click `New Deployment`.
+From your Workspace on Astronomer, click "New Deployment".
 
 ![Workspace Dashboard](https://assets2.astronomer.io/main/docs/astronomer-ui/workspace_dashboard.png)
 

--- a/enterprise/v0.16/04_deploy/03_configure-deployment.md
+++ b/enterprise/v0.16/04_deploy/03_configure-deployment.md
@@ -43,7 +43,7 @@ If your Airflow UI is really slow or crashes when you try to load a large DAG, y
 
 ### Extra Capacity
 
-The **Extra Capacity** setting is tied to the [KubernetesPodOperator](https://www.astronomer.io/docs/kubepodoperator/) and the KubernetesExecutor, as it maps to extra pods created in the cluster. Namely, the slider effects:
+The **Extra Capacity** setting is tied to the [KubernetesPodOperator](https://www.astronomer.io/docs/kubepodoperator/) and the KubernetesExecutor, as it maps to extra pods created in the cluster. Namely, the slider affects:
 
 1. CPU and memory quotas
 2. Database connection limits.

--- a/enterprise/v0.16/04_deploy/03_configure-deployment.md
+++ b/enterprise/v0.16/04_deploy/03_configure-deployment.md
@@ -8,12 +8,12 @@ Once you've created your deployment, you can configure it for the use case at ha
 
 ## Allocating Resources
 
-The `Settings` tab allows you to adjust your resource components - empowering you to freely scale your deployment up or down as you wish. To this end, you can:
+The "Settings" tab allows you to adjust your resource components - empowering you to freely scale your deployment up or down as you wish. To this end, you can:
 
 1. Choose your Executor (Local, Celery, or Kubernetes)
 2. Adjust resources to your Scheduler and Webserver
-3. Adjust worker count (*Celery only*)
-4. Adjust your `Worker Termination Grace Period` (*Celery only*)
+3. Adjust Worker Count (*Celery only*)
+4. Adjust your Worker Termination Grace Period (*Celery only*)
 5. Add Extra Capacity (*Kubernetes or KubernetesPodOperator only*)
 
 ![Astro UI Executor Config](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.15-Astro-UI-Executor.png)
@@ -43,7 +43,7 @@ If your Airflow UI is really slow or crashes when you try to load a large DAG, y
 
 ### Extra Capacity
 
-The `Extra Capacity` setting is tied to the [KubernetesPodOperator](https://www.astronomer.io/docs/kubepodoperator/) and the KubernetesExecutor, as it maps to extra pods created in the cluster. Namely, the slider effects:
+The **Extra Capacity** setting is tied to the [KubernetesPodOperator](https://www.astronomer.io/docs/kubepodoperator/) and the KubernetesExecutor, as it maps to extra pods created in the cluster. Namely, the slider effects:
 
 1. CPU and memory quotas
 2. Database connection limits.

--- a/enterprise/v0.16/04_deploy/05_environment-variables.md
+++ b/enterprise/v0.16/04_deploy/05_environment-variables.md
@@ -129,7 +129,7 @@ The last way to add Environment Variables on Astronomer is to add them via the A
 To set them,
 
 1. Navigate to the Astronomer UI
-2. Go to `Deployment` > `Variables`
+2. Go to **Deployment** > **Variables**
 3. Add your Environment Variables
 
 ![Astro UI Env Vars Config](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.16-Astro-UI-EnvVars.png)
@@ -140,32 +140,32 @@ To set them,
 
 On Astronomer, users have the ability to mark any Environment Variable as "secret" via the UI. For those who have Environment Variables containing potentially sensitive information (e.g. SMTP password, S3 bucket, etc.), we'd recommend leveraging this feature.
 
-To do so from the `Variables` tab,
+To do so from the "Variables" tab,
 
 1. Enter a Key
 2. Enter a Value
-3. Check off the `Secret?` box
-4. Click `Add`
-5. Press `Deploy Changes`
+3. Check the "Secret?" box
+4. Click "Add"
+5. Press "Deploy Changes"
 
-Once changes are deployed, Environment Variables marked as 'secret' will NOT be available in plain-text to any user in the Workspace.
+Once changes are deployed, Environment Variables marked as "secret" will NOT be available in plain-text to any user in the Workspace.
 
 A few additional notes:
 
-- Workspace Editors and Admins are free to set an existing non-secret Env Var to 'secret' any time
-- To convert a 'secret' Env Var to a 'non-secret' Env Var, you'll be prompted to enter a new value
-- If you export Environment Variables via JSON, 'secret' values will NOT render in plain-text
+- Workspace Editors and Admins are free to set an existing non-secret Env Var to "secret" any time
+- To convert a "secret" Env Var to a "non-secret" Env Var, you'll be prompted to enter a new value
+- If you export Environment Variables via JSON, "secret" values will NOT render in plain-text
 - Users cannot add a new variable that has the same key as an existing variable
 
 Read below for more detail on how Environment Variables are encrypted on Astronomer.
 
-> **Note:** As noted above, Workspace roles and permissions apply to actions in the `Variables` tab. For a full breakdown of permissions for each role, reference Astronomer's ["Roles and Permissions" doc](https://www.astronomer.io/docs/rbac/).
+> **Note:** As noted above, Workspace roles and permissions apply to actions in the "Variables" tab. For a full breakdown of permissions for each role, reference Astronomer's ["Roles and Permissions" doc](https://www.astronomer.io/docs/rbac/).
 
 ### Precedence amongst 3 Methods
 
 Given the ability to set Environment Variables across 3 different methods potentially simultaneously, it's worth noting the precedence each take.
 
-On Astronomer, Environment Variables will be applied and overriden in the following order:
+On Astronomer, Environment Variables will be applied and overridden in the following order:
 
 1. Astronomer UI
 2. .env (_Local Only_)

--- a/enterprise/v0.16/04_deploy/05_environment-variables.md
+++ b/enterprise/v0.16/04_deploy/05_environment-variables.md
@@ -129,7 +129,7 @@ The last way to add Environment Variables on Astronomer is to add them via the A
 To set them,
 
 1. Navigate to the Astronomer UI
-2. Go to **Deployment** > **Variables**
+2. Go to "Deployment" > "Variables"
 3. Add your Environment Variables
 
 ![Astro UI Env Vars Config](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.16-Astro-UI-EnvVars.png)

--- a/enterprise/v0.16/04_deploy/06_ci-cd.md
+++ b/enterprise/v0.16/04_deploy/06_ci-cd.md
@@ -97,7 +97,7 @@ Upon creating a Service Account, make sure to:
 * Give it a Category (optional)
 * Grant it a User Role
 
-> **Note:** In order for a Service Account to have permission to push code to your Airflow Deployment, it must have either the `Editor` or `Admin` role. For more information on Workspace roles, refer to our ["Roles and Permissions"](https://www.astronomer.io/docs/rbac/) doc.
+> **Note:** In order for a Service Account to have permission to push code to your Airflow Deployment, it must have either the "Editor" or "Admin" role. For more information on Workspace roles, refer to our ["Roles and Permissions"](https://www.astronomer.io/docs/rbac/) doc.
 
 ![Name Service Account](https://assets2.astronomer.io/main/docs/ci-cd/ci-cd-name-service-account.png)
 
@@ -128,7 +128,7 @@ Once you are authenticated you can build, tag and push your Airflow image to the
 
 #### Registry Address
 
-*Registry Address* tells Docker where to push images to. In the case of Astronomer Enterprise, your private registry located at registry.${BASE_DOMAIN}.
+*Registry Address* tells Docker where to push images to. In the case of Astronomer Enterprise, your private registry located at `registry.${BASE_DOMAIN}`.
 
 
 #### Release Name
@@ -137,7 +137,7 @@ Once you are authenticated you can build, tag and push your Airflow image to the
 
 #### Tag Name
 
-*Tag Name*: Each deploy to Astronomer generates a Docker image with a corresponding tag. If you deploy via the CLI, the tag will by default read `deploy-n`, with `n` representing the numnber of deploys made to that Airflow Deployment. If you're using CI/CD, you get to customize this tag. We typically recommend specifying the source and the build number in the name.
+*Tag Name*: Each deploy to Astronomer generates a Docker image with a corresponding tag. If you deploy via the CLI, the tag will by default read `deploy-n`, with `n` representing the number of deploys made to that Airflow Deployment. If you're using CI/CD, you get to customize this tag. We typically recommend specifying the source and the build number in the name.
 
 In the example below, we use the prefix `ci-` and the ENV `${DRONE_BUILD_NUMBER}`. This guarantees that we always know which CI/CD build triggered the build and push.
 


### PR DESCRIPTION
@paolaperaza I know we had this conversation at some point about the use of `code` formatting in our Markdown. This isn't a complete audit of our existing docs, but a substantial one. I've replaced many of the inline code blocks (that weren't code) with `"word"` or `**word**` formatting. I've tried to use the quotes in places where it was a verbatim reference to something in the UI. e.g. `Click the **Settings** tab.`

Found a handful of spelling errors that I've fixed as well, and adjusted a few sentences that felt a bit off.